### PR TITLE
Add admin editing for super admins

### DIFF
--- a/app/api/super-admin/organizations/[id]/admin/route.ts
+++ b/app/api/super-admin/organizations/[id]/admin/route.ts
@@ -1,0 +1,29 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { getServerSession } from "next-auth/next"
+import type { Session } from "next-auth"
+import { authOptions } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session: Session | null = await getServerSession(authOptions)
+
+    if (!session || session.user.role !== "SUPER_ADMIN") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const admin = await prisma.user.findFirst({
+      where: { organizationId: params.id, role: "ADMIN" },
+      select: { id: true, name: true, email: true },
+    })
+
+    if (!admin) {
+      return NextResponse.json({ error: "Admin user not found" }, { status: 404 })
+    }
+
+    return NextResponse.json(admin)
+  } catch (error) {
+    console.error("Error fetching admin user:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/app/api/super-admin/users/[id]/route.ts
+++ b/app/api/super-admin/users/[id]/route.ts
@@ -1,0 +1,73 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { getServerSession } from "next-auth/next"
+import type { Session } from "next-auth"
+import { authOptions } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session: Session | null = await getServerSession(authOptions)
+
+    if (!session || session.user.role !== "SUPER_ADMIN") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: params.id },
+      select: { id: true, name: true, email: true, role: true, organizationId: true },
+    })
+
+    if (!user || user.role !== "ADMIN") {
+      return NextResponse.json({ error: "User not found" }, { status: 404 })
+    }
+
+    return NextResponse.json(user)
+  } catch (error) {
+    console.error("Error fetching user:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session: Session | null = await getServerSession(authOptions)
+
+    if (!session || session.user.role !== "SUPER_ADMIN") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { name, email } = await request.json()
+
+    const existingUser = await prisma.user.findUnique({ where: { id: params.id } })
+
+    if (!existingUser || existingUser.role !== "ADMIN") {
+      return NextResponse.json({ error: "User not found" }, { status: 404 })
+    }
+
+    if (email && email !== existingUser.email) {
+      const emailExists = await prisma.user.findFirst({
+        where: {
+          email,
+          id: { not: params.id },
+        },
+      })
+
+      if (emailExists) {
+        return NextResponse.json({ error: "Email already exists" }, { status: 400 })
+      }
+    }
+
+    const user = await prisma.user.update({
+      where: { id: params.id },
+      data: {
+        name,
+        email,
+      },
+    })
+
+    return NextResponse.json({ message: "User updated successfully", user })
+  } catch (error) {
+    console.error("Error updating user:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}

--- a/components/super-admin/edit-admin-dialog.tsx
+++ b/components/super-admin/edit-admin-dialog.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import type React from "react"
+import { useState, useEffect } from "react"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { useToast } from "@/hooks/use-toast"
+import { Loader2 } from "lucide-react"
+
+interface EditAdminDialogProps {
+  organizationId: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: () => void
+}
+
+interface AdminUser {
+  id: string
+  name?: string
+  email: string
+}
+
+export function EditAdminDialog({ organizationId, open, onOpenChange, onSuccess }: EditAdminDialogProps) {
+  const [loading, setLoading] = useState(false)
+  const [loadingData, setLoadingData] = useState(false)
+  const [admin, setAdmin] = useState<AdminUser | null>(null)
+  const [name, setName] = useState("")
+  const [email, setEmail] = useState("")
+  const { toast } = useToast()
+
+  useEffect(() => {
+    if (open && organizationId) {
+      fetchAdmin()
+    }
+  }, [open, organizationId])
+
+  const fetchAdmin = async () => {
+    if (!organizationId) return
+    setLoadingData(true)
+    try {
+      const response = await fetch(`/api/super-admin/organizations/${organizationId}/admin`)
+      if (response.ok) {
+        const data = await response.json()
+        setAdmin(data)
+        setName(data.name || "")
+        setEmail(data.email)
+      } else {
+        const error = await response.json()
+        toast({
+          title: "Error",
+          description: error.error || "Failed to load admin",
+          variant: "destructive",
+        })
+        onOpenChange(false)
+      }
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "An unexpected error occurred",
+        variant: "destructive",
+      })
+      onOpenChange(false)
+    } finally {
+      setLoadingData(false)
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!admin) return
+
+    setLoading(true)
+    try {
+      const response = await fetch(`/api/super-admin/users/${admin.id}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          name: name.trim() || null,
+          email: email.trim(),
+        }),
+      })
+
+      if (response.ok) {
+        toast({
+          title: "Success",
+          description: "Admin updated successfully.",
+        })
+        onSuccess()
+        onOpenChange(false)
+      } else {
+        const error = await response.json()
+        toast({
+          title: "Error",
+          description: error.error || "Failed to update admin",
+          variant: "destructive",
+        })
+      }
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: "An unexpected error occurred",
+        variant: "destructive",
+      })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Edit Admin</DialogTitle>
+        </DialogHeader>
+        {loadingData ? (
+          <div className="py-4 text-center">Loading...</div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="name">Name (Optional)</Label>
+              <Input id="name" value={name} onChange={(e) => setName(e.target.value)} disabled={loading} />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email *</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                disabled={loading}
+              />
+            </div>
+            <div className="flex justify-end space-x-2">
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={loading}>
+                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Update Admin
+              </Button>
+            </div>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/super-admin/organizations-list.tsx
+++ b/components/super-admin/organizations-list.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { MoreHorizontal, Edit, Trash2 } from "lucide-react"
+import { MoreHorizontal, Edit, Trash2, UserCog } from "lucide-react"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import {
   AlertDialog,
@@ -17,6 +17,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
 import { EditOrganizationDialog } from "./edit-organization-dialog"
+import { EditAdminDialog } from "./edit-admin-dialog"
 import { useToast } from "@/hooks/use-toast"
 import { formatDate } from "@/lib/utils"
 
@@ -42,6 +43,8 @@ export function OrganizationsList({ onUpdate }: OrganizationsListProps) {
   const [editingOrganization, setEditingOrganization] = useState<Organization | null>(null)
   const [deletingOrganization, setDeletingOrganization] = useState<Organization | null>(null)
   const [showEditDialog, setShowEditDialog] = useState(false)
+  const [showEditAdminDialog, setShowEditAdminDialog] = useState(false)
+  const [editingAdminOrgId, setEditingAdminOrgId] = useState<string | null>(null)
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const { toast } = useToast()
 
@@ -66,6 +69,11 @@ export function OrganizationsList({ onUpdate }: OrganizationsListProps) {
   const handleEdit = (organization: Organization) => {
     setEditingOrganization(organization)
     setShowEditDialog(true)
+  }
+
+  const handleEditAdmin = (organization: Organization) => {
+    setEditingAdminOrgId(organization.id)
+    setShowEditAdminDialog(true)
   }
 
   const handleDelete = (organization: Organization) => {
@@ -156,9 +164,13 @@ export function OrganizationsList({ onUpdate }: OrganizationsListProps) {
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={() => handleEdit(org)}>
+                  <DropdownMenuItem onClick={() => handleEdit(org)}>
                       <Edit className="mr-2 h-4 w-4" />
                       Edit
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => handleEditAdmin(org)}>
+                      <UserCog className="mr-2 h-4 w-4" />
+                      Edit Admin
                     </DropdownMenuItem>
                     <DropdownMenuItem
                       className="text-red-600"
@@ -184,6 +196,16 @@ export function OrganizationsList({ onUpdate }: OrganizationsListProps) {
           fetchOrganizations()
         }}
         organization={editingOrganization}
+      />
+
+      <EditAdminDialog
+        open={showEditAdminDialog}
+        onOpenChange={setShowEditAdminDialog}
+        onSuccess={() => {
+          onUpdate()
+          fetchOrganizations()
+        }}
+        organizationId={editingAdminOrgId}
       />
 
       <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>


### PR DESCRIPTION
## Summary
- add super-admin API route to update user information
- expose API to fetch an organization's admin
- allow editing admin details from the organizations list
- refresh dashboard data after admin edits

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_685834fb7484832aac241f996eeed6ff