### PR TITLE
fix api caching

### DIFF
--- a/app/api/super-admin/organizations/route.ts
+++ b/app/api/super-admin/organizations/route.ts
@@ -112,3 +112,5 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })
   }
 }
+
+export const dynamic = "force-dynamic"


### PR DESCRIPTION
## Summary
- make the super-admin organizations API always dynamic

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_685835346b00832abcfeecfddba058ac