### PR TITLE
Fix user creation with no area or department

### DIFF
--- a/components/admin/create-user-dialog.tsx
+++ b/components/admin/create-user-dialog.tsx
@@ -95,8 +95,11 @@ export function CreateUserDialog({ open, onOpenChange, onSuccess }: CreateUserDi
         },
         body: JSON.stringify({
           ...formData,
-          areaId: formData.areaId === "" ? "NONE" : formData.areaId,
-          departmentId: formData.departmentId === "" ? "NONE" : formData.departmentId,
+          areaId: formData.areaId === "" || formData.areaId === "none" ? "NONE" : formData.areaId,
+          departmentId:
+            formData.departmentId === "" || formData.departmentId === "none"
+              ? "NONE"
+              : formData.departmentId,
         }),
       })
 

--- a/components/mini-admin/create-user-dialog.tsx
+++ b/components/mini-admin/create-user-dialog.tsx
@@ -63,7 +63,10 @@ export function CreateUserDialog({ open, onOpenChange, onSuccess }: CreateUserDi
         },
         body: JSON.stringify({
           ...formData,
-          departmentId: formData.departmentId === "" ? null : formData.departmentId,
+          departmentId:
+            formData.departmentId === "" || formData.departmentId === "none"
+              ? null
+              : formData.departmentId,
         }),
       })
 


### PR DESCRIPTION
## Summary
- handle explicit 'none' selections when creating users

## Testing
- `CI=1 npm run lint` *(fails: npm prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_685837ab5194832a8f0eab17a1b37a9f