### PR TITLE
Implement audit logs and email update workflow

### DIFF
--- a/app/api/admin/departments/[id]/route.ts
+++ b/app/api/admin/departments/[id]/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "@/lib/auth"
 import type { Session } from "next-auth"
 import { prisma } from "@/lib/prisma"
+import { createAuditLog } from "@/lib/audit"
 
 export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -54,6 +55,8 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
         areaId: areaId === "none" ? null : areaId,
       },
     })
+
+    await createAuditLog(session.user.id, "UPDATE_DEPARTMENT", "Department", params.id)
 
     return NextResponse.json({
       message: "Department updated successfully",
@@ -108,6 +111,8 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     await prisma.department.delete({
       where: { id: params.id },
     })
+
+    await createAuditLog(session.user.id, "DELETE_DEPARTMENT", "Department", params.id)
 
     return NextResponse.json({
       message: "Department deleted successfully",

--- a/app/api/admin/departments/route.ts
+++ b/app/api/admin/departments/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "@/lib/auth"
 import type { Session } from "next-auth"
 import { prisma } from "@/lib/prisma"
+import { createAuditLog } from "@/lib/audit"
 
 export async function GET() {
   try {
@@ -84,6 +85,8 @@ export async function POST(request: NextRequest) {
         areaId: areaId === "none" ? null : areaId,
       },
     })
+
+    await createAuditLog(session.user.id, "CREATE_DEPARTMENT", "Department", department.id)
 
     return NextResponse.json({
       message: "Department created successfully",

--- a/app/api/admin/templates/[id]/route.ts
+++ b/app/api/admin/templates/[id]/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next"
 import type { Session } from "next-auth"
 import { authOptions } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
+import { createAuditLog } from "@/lib/audit"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -89,6 +90,8 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       },
     })
 
+    await createAuditLog(session.user.id, "UPDATE_TEMPLATE", "Template", params.id)
+
     return NextResponse.json({
       message: "Template updated successfully",
       template,
@@ -137,6 +140,8 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     await prisma.masterTemplate.delete({
       where: { id: params.id },
     })
+
+    await createAuditLog(session.user.id, "DELETE_TEMPLATE", "Template", params.id)
 
     return NextResponse.json({
       message: "Template deleted successfully",

--- a/app/api/admin/templates/route.ts
+++ b/app/api/admin/templates/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "@/lib/auth"
 import type { Session } from "next-auth"
 import { prisma } from "@/lib/prisma"
+import { createAuditLog } from "@/lib/audit"
 
 export async function GET() {
   try {
@@ -84,6 +85,8 @@ export async function POST(request: NextRequest) {
         departmentId: departmentId === "none" || departmentId === "" ? null : departmentId,
       },
     })
+
+    await createAuditLog(session.user.id, "CREATE_TEMPLATE", "Template", template.id)
 
     return NextResponse.json({
       message: "Template created successfully",

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -4,6 +4,7 @@ import { authOptions } from "@/lib/auth"
 import type { Session } from "next-auth"
 import { prisma } from "@/lib/prisma"
 import { sendAccountSetupEmail } from "@/lib/email"
+import { createAuditLog } from "@/lib/audit"
 import { generateResetToken } from "@/lib/utils"
 import bcrypt from "bcryptjs"
 
@@ -145,6 +146,8 @@ export async function POST(request: NextRequest) {
       organization?.name || "Organization",
       result.resetToken,
     )
+
+    await createAuditLog(session.user.id, "CREATE_USER", "User", result.user.id)
 
     return NextResponse.json({
       message: "User created successfully",

--- a/app/api/mini-admin/departments/[id]/route.ts
+++ b/app/api/mini-admin/departments/[id]/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next"
 import type { Session } from "next-auth"
 import { authOptions } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
+import { createAuditLog } from "@/lib/audit"
 
 export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -39,6 +40,8 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
         description,
       },
     })
+
+    await createAuditLog(session.user.id, "UPDATE_DEPARTMENT", "Department", params.id)
 
     return NextResponse.json({
       message: "Department updated successfully",
@@ -93,6 +96,8 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     await prisma.department.delete({
       where: { id: params.id },
     })
+
+    await createAuditLog(session.user.id, "DELETE_DEPARTMENT", "Department", params.id)
 
     return NextResponse.json({
       message: "Department deleted successfully",

--- a/app/api/mini-admin/departments/route.ts
+++ b/app/api/mini-admin/departments/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "@/lib/auth"
 import type { Session } from "next-auth"
 import { prisma } from "@/lib/prisma"
+import { createAuditLog } from "@/lib/audit"
 
 export async function GET() {
   try {
@@ -66,6 +67,8 @@ export async function POST(request: NextRequest) {
         areaId,
       },
     })
+
+    await createAuditLog(session.user.id, "CREATE_DEPARTMENT", "Department", department.id)
 
     return NextResponse.json({
       message: "Department created successfully",

--- a/app/api/mini-admin/templates/[id]/route.ts
+++ b/app/api/mini-admin/templates/[id]/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next"
 import type { Session } from "next-auth"
 import { authOptions } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
+import { createAuditLog } from "@/lib/audit"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -120,9 +121,55 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       },
     })
 
+    await createAuditLog(session.user.id, "UPDATE_TEMPLATE", "Template", params.id)
+
     return NextResponse.json(updatedTemplate)
   } catch (error) {
     console.error("Error updating template:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}
+
+export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session: Session | null = await getServerSession(authOptions)
+
+    if (!session || session.user.role !== "MINI_ADMIN") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const areaId = session.user.areaId
+
+    if (!areaId) {
+      return NextResponse.json({ error: "Area not found" }, { status: 400 })
+    }
+
+    const existingTemplate = await prisma.masterTemplate.findFirst({
+      where: {
+        id: params.id,
+        department: { areaId },
+      },
+    })
+
+    if (!existingTemplate) {
+      return NextResponse.json({ error: "Template not found" }, { status: 404 })
+    }
+
+    const inspectionCount = await prisma.inspectionInstance.count({
+      where: { masterTemplateId: params.id },
+    })
+
+    if (inspectionCount > 0) {
+      return NextResponse.json({ error: "Cannot delete template with existing inspections" }, { status: 400 })
+    }
+
+    await prisma.masterTemplate.delete({ where: { id: params.id } })
+
+    await createAuditLog(session.user.id, "DELETE_TEMPLATE", "Template", params.id)
+
+    return NextResponse.json({ message: "Template deleted" })
+  } catch (error) {
+    console.error("Error deleting template:", error)
     return NextResponse.json({ error: "Internal server error" }, { status: 500 })
   }
 }

--- a/app/api/mini-admin/templates/route.ts
+++ b/app/api/mini-admin/templates/route.ts
@@ -3,6 +3,7 @@ import { getServerSession } from "next-auth/next"
 import { authOptions } from "@/lib/auth"
 import type { Session } from "next-auth"
 import { prisma } from "@/lib/prisma"
+import { createAuditLog } from "@/lib/audit"
 
 export async function GET() {
   try {
@@ -89,6 +90,8 @@ export async function POST(request: NextRequest) {
         departmentId: departmentId || null,
       },
     })
+
+    await createAuditLog(session.user.id, "CREATE_TEMPLATE", "Template", template.id)
 
     return NextResponse.json({
       message: "Template created successfully",

--- a/app/api/mini-admin/users/[id]/route.ts
+++ b/app/api/mini-admin/users/[id]/route.ts
@@ -3,6 +3,9 @@ import { getServerSession } from "next-auth/next"
 import type { Session } from "next-auth"
 import { authOptions } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
+import { sendEmailUpdateNotification } from "@/lib/email"
+import { generateResetToken } from "@/lib/utils"
+import { createAuditLog } from "@/lib/audit"
 
 export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -60,6 +63,8 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       }
     }
 
+    const emailChanged = email !== existingUser.email
+
     const user = await prisma.user.update({
       where: { id: params.id },
       data: {
@@ -69,6 +74,22 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
         departmentId: departmentId || null,
       },
     })
+
+    if (emailChanged) {
+      const resetToken = generateResetToken()
+      await prisma.verificationToken.create({
+        data: {
+          identifier: email,
+          token: resetToken,
+          expires: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        },
+      })
+      await prisma.session.deleteMany({ where: { userId: params.id } })
+      await sendEmailUpdateNotification(email, resetToken)
+      await createAuditLog(session.user.id, "UPDATE_USER_EMAIL", "User", params.id)
+    } else {
+      await createAuditLog(session.user.id, "UPDATE_USER", "User", params.id)
+    }
 
     return NextResponse.json({
       message: "User updated successfully",
@@ -123,6 +144,8 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     await prisma.user.delete({
       where: { id: params.id },
     })
+
+    await createAuditLog(session.user.id, "DELETE_USER", "User", params.id)
 
     return NextResponse.json({
       message: "User deleted successfully",

--- a/app/api/mini-admin/users/route.ts
+++ b/app/api/mini-admin/users/route.ts
@@ -4,6 +4,7 @@ import type { Session } from "next-auth"
 import { authOptions } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
 import { sendAccountSetupEmail } from "@/lib/email"
+import { createAuditLog } from "@/lib/audit"
 import { generateResetToken } from "@/lib/utils"
 import bcrypt from "bcryptjs"
 
@@ -128,6 +129,8 @@ export async function POST(request: NextRequest) {
       organization?.name || "Organization",
       result.resetToken,
     )
+
+    await createAuditLog(session.user.id, "CREATE_USER", "User", result.user.id)
 
     return NextResponse.json({
       message: "User created successfully",

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -1,0 +1,16 @@
+import { prisma } from "./prisma"
+
+export async function createAuditLog(userId: string, action: string, entity: string, entityId?: string) {
+  try {
+    await prisma.auditLog.create({
+      data: {
+        userId,
+        action,
+        entity,
+        entityId: entityId || null,
+      },
+    })
+  } catch (error) {
+    console.error("Failed to create audit log", error)
+  }
+}

--- a/lib/email-fallback.ts
+++ b/lib/email-fallback.ts
@@ -43,3 +43,17 @@ export async function sendAccountSetupEmailFallback(
 
   return Promise.resolve()
 }
+
+export async function sendEmailUpdateNotificationFallback(
+  email: string,
+  resetToken: string,
+) {
+  const resetUrl = `${process.env.NEXTAUTH_URL}/auth/reset-password?token=${resetToken}`
+
+  console.log("=== EMAIL UPDATE NOTIFICATION ===")
+  console.log(`To: ${email}`)
+  console.log(`Reset URL: ${resetUrl}`)
+  console.log("=================================")
+
+  return Promise.resolve()
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,26 +39,27 @@ model Session {
 }
 
 model User {
-  id            String    @id @default(cuid())
-  name          String?
-  email         String    @unique
-  emailVerified DateTime?
-  image         String?
-  password      String?
-  role          UserRole  @default(INSPECTOR)
+  id             String    @id @default(cuid())
+  name           String?
+  email          String    @unique
+  emailVerified  DateTime?
+  image          String?
+  password       String?
+  role           UserRole  @default(INSPECTOR)
   organizationId String?
-  areaId        String?
-  departmentId  String?
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  areaId         String?
+  departmentId   String?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 
-  accounts      Account[]
-  sessions      Session[]
-  organization  Organization? @relation(fields: [organizationId], references: [id])
-  area          Area?         @relation(fields: [areaId], references: [id])
-  department    Department?   @relation(fields: [departmentId], references: [id])
-  inspections   InspectionInstance[]
-  followUps     FollowUp[]
+  accounts     Account[]
+  sessions     Session[]
+  organization Organization?        @relation(fields: [organizationId], references: [id])
+  area         Area?                @relation(fields: [areaId], references: [id])
+  department   Department?          @relation(fields: [departmentId], references: [id])
+  inspections  InspectionInstance[]
+  followUps    FollowUp[]
+  auditLogs    AuditLog[]
 }
 
 model VerificationToken {
@@ -104,27 +105,27 @@ model Department {
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
-  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  area         Area?        @relation(fields: [areaId], references: [id])
+  organization Organization         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  area         Area?                @relation(fields: [areaId], references: [id])
   users        User[]
   templates    MasterTemplate[]
   inspections  InspectionInstance[]
 }
 
 model MasterTemplate {
-  id             String            @id @default(cuid())
+  id             String   @id @default(cuid())
   name           String
   description    String?
-  frequency      Int               // Days between inspections
+  frequency      Int // Days between inspections
   organizationId String
   departmentId   String?
-  createdAt      DateTime          @default(now())
-  updatedAt      DateTime          @updatedAt
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
-  organization    Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  department      Department?        @relation(fields: [departmentId], references: [id])
-  checklistItems  ChecklistItem[]
-  inspections     InspectionInstance[]
+  organization   Organization         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  department     Department?          @relation(fields: [departmentId], references: [id])
+  checklistItems ChecklistItem[]
+  inspections    InspectionInstance[]
 }
 
 model ChecklistItem {
@@ -138,24 +139,24 @@ model ChecklistItem {
   createdAt        DateTime @default(now())
   updatedAt        DateTime @updatedAt
 
-  masterTemplate MasterTemplate    @relation(fields: [masterTemplateId], references: [id], onDelete: Cascade)
+  masterTemplate MasterTemplate     @relation(fields: [masterTemplateId], references: [id], onDelete: Cascade)
   reportItems    ReportItemResult[]
 }
 
 model InspectionInstance {
-  id               String            @id @default(cuid())
+  id               String           @id @default(cuid())
   masterTemplateId String
   inspectorId      String
   departmentId     String
-  status           InspectionStatus  @default(PENDING)
+  status           InspectionStatus @default(PENDING)
   dueDate          DateTime
   completedAt      DateTime?
-  createdAt        DateTime          @default(now())
-  updatedAt        DateTime          @updatedAt
+  createdAt        DateTime         @default(now())
+  updatedAt        DateTime         @updatedAt
 
-  masterTemplate MasterTemplate     @relation(fields: [masterTemplateId], references: [id])
-  inspector      User               @relation(fields: [inspectorId], references: [id])
-  department     Department         @relation(fields: [departmentId], references: [id])
+  masterTemplate MasterTemplate    @relation(fields: [masterTemplateId], references: [id])
+  inspector      User              @relation(fields: [inspectorId], references: [id])
+  department     Department        @relation(fields: [departmentId], references: [id])
   report         InspectionReport?
 }
 
@@ -174,33 +175,44 @@ model InspectionReport {
 }
 
 model ReportItemResult {
-  id                String   @id @default(cuid())
-  checklistItemId   String
+  id                 String   @id @default(cuid())
+  checklistItemId    String
   inspectionReportId String
-  approved          Boolean
-  comments          String?
-  imageUrl          String?
-  createdAt         DateTime @default(now())
-  updatedAt         DateTime @updatedAt
+  approved           Boolean
+  comments           String?
+  imageUrl           String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
 
-  checklistItem     ChecklistItem    @relation(fields: [checklistItemId], references: [id])
-  inspectionReport  InspectionReport @relation(fields: [inspectionReportId], references: [id], onDelete: Cascade)
+  checklistItem    ChecklistItem    @relation(fields: [checklistItemId], references: [id])
+  inspectionReport InspectionReport @relation(fields: [inspectionReportId], references: [id], onDelete: Cascade)
 
   @@unique([checklistItemId, inspectionReportId])
 }
 
 model FollowUp {
-  id                 String   @id @default(cuid())
+  id                 String    @id @default(cuid())
   inspectionReportId String
   userId             String
   note               String
-  handled            Boolean  @default(false)
+  handled            Boolean   @default(false)
   handledAt          DateTime?
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
 
   inspectionReport InspectionReport @relation(fields: [inspectionReportId], references: [id], onDelete: Cascade)
   user             User             @relation(fields: [userId], references: [id])
+}
+
+model AuditLog {
+  id        String   @id @default(cuid())
+  userId    String
+  action    String
+  entity    String
+  entityId  String?
+  createdAt DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 enum UserRole {


### PR DESCRIPTION
## Summary
- add AuditLog model and helper
- send email update notifications and force logout on email change
- record audit logs on user, department and template modifications
- allow MINI_ADMIN to delete templates

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: Next.js build incomplete)*

------
https://chatgpt.com/codex/tasks/task_b_68583c9dc43c832abb0dcbb456ce4b0f