### PR TITLE
Allow admins delete items with associations

### DIFF
--- a/app/api/admin/areas/[id]/route.ts
+++ b/app/api/admin/areas/[id]/route.ts
@@ -76,16 +76,6 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
       return NextResponse.json({ error: "Area not found" }, { status: 404 })
     }
 
-    // Check if area has departments or users
-    const [departmentCount, userCount] = await Promise.all([
-      prisma.department.count({ where: { areaId: params.id } }),
-      prisma.user.count({ where: { areaId: params.id } }),
-    ])
-
-    if (departmentCount > 0 || userCount > 0) {
-      return NextResponse.json({ error: "Cannot delete area with existing departments or users" }, { status: 400 })
-    }
-
     await prisma.area.delete({
       where: { id: params.id },
     })

--- a/app/api/admin/departments/[id]/route.ts
+++ b/app/api/admin/departments/[id]/route.ts
@@ -94,20 +94,6 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
       return NextResponse.json({ error: "Department not found" }, { status: 404 })
     }
 
-    // Check if department has users, templates, or inspections
-    const [userCount, templateCount, inspectionCount] = await Promise.all([
-      prisma.user.count({ where: { departmentId: params.id } }),
-      prisma.masterTemplate.count({ where: { departmentId: params.id } }),
-      prisma.inspectionInstance.count({ where: { departmentId: params.id } }),
-    ])
-
-    if (userCount > 0 || templateCount > 0 || inspectionCount > 0) {
-      return NextResponse.json(
-        { error: "Cannot delete department with existing users, templates, or inspections" },
-        { status: 400 },
-      )
-    }
-
     await prisma.department.delete({
       where: { id: params.id },
     })

--- a/app/api/admin/templates/[id]/route.ts
+++ b/app/api/admin/templates/[id]/route.ts
@@ -128,15 +128,6 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
       return NextResponse.json({ error: "Template not found" }, { status: 404 })
     }
 
-    // Check if template has inspections
-    const inspectionCount = await prisma.inspectionInstance.count({
-      where: { masterTemplateId: params.id },
-    })
-
-    if (inspectionCount > 0) {
-      return NextResponse.json({ error: "Cannot delete template with existing inspections" }, { status: 400 })
-    }
-
     await prisma.masterTemplate.delete({
       where: { id: params.id },
     })

--- a/app/api/mini-admin/departments/[id]/route.ts
+++ b/app/api/mini-admin/departments/[id]/route.ts
@@ -79,20 +79,6 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
       return NextResponse.json({ error: "Department not found" }, { status: 404 })
     }
 
-    // Check if department has users, templates, or inspections
-    const [userCount, templateCount, inspectionCount] = await Promise.all([
-      prisma.user.count({ where: { departmentId: params.id } }),
-      prisma.masterTemplate.count({ where: { departmentId: params.id } }),
-      prisma.inspectionInstance.count({ where: { departmentId: params.id } }),
-    ])
-
-    if (userCount > 0 || templateCount > 0 || inspectionCount > 0) {
-      return NextResponse.json(
-        { error: "Cannot delete department with existing users, templates, or inspections" },
-        { status: 400 },
-      )
-    }
-
     await prisma.department.delete({
       where: { id: params.id },
     })

--- a/app/api/mini-admin/templates/[id]/route.ts
+++ b/app/api/mini-admin/templates/[id]/route.ts
@@ -155,14 +155,6 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
       return NextResponse.json({ error: "Template not found" }, { status: 404 })
     }
 
-    const inspectionCount = await prisma.inspectionInstance.count({
-      where: { masterTemplateId: params.id },
-    })
-
-    if (inspectionCount > 0) {
-      return NextResponse.json({ error: "Cannot delete template with existing inspections" }, { status: 400 })
-    }
-
     await prisma.masterTemplate.delete({ where: { id: params.id } })
 
     await createAuditLog(session.user.id, "DELETE_TEMPLATE", "Template", params.id)

--- a/components/admin/areas-list.tsx
+++ b/components/admin/areas-list.tsx
@@ -106,8 +106,8 @@ export function AreasList({ onUpdate }: AreasListProps) {
     }
   }
 
-  const canDelete = (area: Area) => {
-    return area._count.users === 0 && area._count.departments === 0
+  const canDelete = (_area: Area) => {
+    return true
   }
 
   if (loading) {
@@ -158,7 +158,6 @@ export function AreasList({ onUpdate }: AreasListProps) {
                     <DropdownMenuItem
                       className="text-red-600"
                       onClick={() => handleDelete(area)}
-                      disabled={!canDelete(area)}
                     >
                       <Trash2 className="mr-2 h-4 w-4" />
                       Delete
@@ -187,10 +186,9 @@ export function AreasList({ onUpdate }: AreasListProps) {
             <AlertDialogTitle>Delete Area</AlertDialogTitle>
             <AlertDialogDescription>
               Are you sure you want to delete "{deletingArea?.name}"? This action cannot be undone.
-              {deletingArea && !canDelete(deletingArea) && (
+              {deletingArea && (
                 <span className="block mt-2 text-red-600 font-medium">
-                  This area has {deletingArea._count.users} users and {deletingArea._count.departments} departments and
-                  cannot be deleted.
+                  This area has {deletingArea._count.users} users and {deletingArea._count.departments} departments.
                 </span>
               )}
             </AlertDialogDescription>
@@ -199,7 +197,7 @@ export function AreasList({ onUpdate }: AreasListProps) {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
-              disabled={deletingArea ? !canDelete(deletingArea) : true}
+              disabled={!deletingArea}
               className="bg-red-600 hover:bg-red-700"
             >
               Delete

--- a/components/admin/departments-list.tsx
+++ b/components/admin/departments-list.tsx
@@ -110,8 +110,8 @@ export function DepartmentsList({ onUpdate }: DepartmentsListProps) {
     }
   }
 
-  const canDelete = (department: Department) => {
-    return department._count.users === 0 && department._count.templates === 0 && department._count.inspections === 0
+  const canDelete = (_department: Department) => {
+    return true
   }
 
   if (loading) {
@@ -172,7 +172,6 @@ export function DepartmentsList({ onUpdate }: DepartmentsListProps) {
                     <DropdownMenuItem
                       className="text-red-600"
                       onClick={() => handleDelete(dept)}
-                      disabled={!canDelete(dept)}
                     >
                       <Trash2 className="mr-2 h-4 w-4" />
                       Delete
@@ -201,10 +200,10 @@ export function DepartmentsList({ onUpdate }: DepartmentsListProps) {
             <AlertDialogTitle>Delete Department</AlertDialogTitle>
             <AlertDialogDescription>
               Are you sure you want to delete "{deletingDepartment?.name}"? This action cannot be undone.
-              {deletingDepartment && !canDelete(deletingDepartment) && (
+              {deletingDepartment && (
                 <span className="block mt-2 text-red-600 font-medium">
                   This department has {deletingDepartment._count.users} users, {deletingDepartment._count.templates}{" "}
-                  templates, and {deletingDepartment._count.inspections} inspections and cannot be deleted.
+                  templates, and {deletingDepartment._count.inspections} inspections.
                 </span>
               )}
             </AlertDialogDescription>
@@ -213,7 +212,7 @@ export function DepartmentsList({ onUpdate }: DepartmentsListProps) {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
-              disabled={deletingDepartment ? !canDelete(deletingDepartment) : true}
+              disabled={!deletingDepartment}
               className="bg-red-600 hover:bg-red-700"
             >
               Delete

--- a/components/admin/templates-list.tsx
+++ b/components/admin/templates-list.tsx
@@ -110,8 +110,8 @@ export function TemplatesList({ onUpdate }: TemplatesListProps) {
     }
   }
 
-  const canDelete = (template: Template) => {
-    return template._count.inspections === 0
+  const canDelete = (_template: Template) => {
+    return true
   }
 
   if (loading) {
@@ -174,7 +174,6 @@ export function TemplatesList({ onUpdate }: TemplatesListProps) {
                     <DropdownMenuItem
                       className="text-red-600"
                       onClick={() => handleDelete(template)}
-                      disabled={!canDelete(template)}
                     >
                       <Trash2 className="mr-2 h-4 w-4" />
                       Delete
@@ -202,9 +201,9 @@ export function TemplatesList({ onUpdate }: TemplatesListProps) {
             <AlertDialogTitle>Delete Template</AlertDialogTitle>
             <AlertDialogDescription>
               Are you sure you want to delete "{deletingTemplate?.name}"? This action cannot be undone.
-              {deletingTemplate && !canDelete(deletingTemplate) && (
+              {deletingTemplate && (
                 <span className="block mt-2 text-red-600 font-medium">
-                  This template has {deletingTemplate._count.inspections} inspections and cannot be deleted.
+                  This template has {deletingTemplate._count.inspections} inspections.
                 </span>
               )}
             </AlertDialogDescription>
@@ -213,7 +212,7 @@ export function TemplatesList({ onUpdate }: TemplatesListProps) {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
-              disabled={deletingTemplate ? !canDelete(deletingTemplate) : true}
+              disabled={!deletingTemplate}
               className="bg-red-600 hover:bg-red-700"
             >
               Delete

--- a/components/mini-admin/departments-list.tsx
+++ b/components/mini-admin/departments-list.tsx
@@ -107,8 +107,8 @@ export function DepartmentsList({ onUpdate }: DepartmentsListProps) {
     }
   }
 
-  const canDelete = (department: Department) => {
-    return department._count.users === 0 && department._count.templates === 0 && department._count.inspections === 0
+  const canDelete = (_department: Department) => {
+    return true
   }
 
   if (loading) {
@@ -167,7 +167,6 @@ export function DepartmentsList({ onUpdate }: DepartmentsListProps) {
                     <DropdownMenuItem
                       className="text-red-600"
                       onClick={() => handleDelete(dept)}
-                      disabled={!canDelete(dept)}
                     >
                       <Trash2 className="mr-2 h-4 w-4" />
                       Delete
@@ -196,11 +195,10 @@ export function DepartmentsList({ onUpdate }: DepartmentsListProps) {
             <AlertDialogTitle>Delete Department</AlertDialogTitle>
             <AlertDialogDescription>
               Are you sure you want to delete "{deletingDepartment?.name}"? This action cannot be undone.
-              {deletingDepartment && !canDelete(deletingDepartment) && (
+              {deletingDepartment && (
                 <span className="block mt-2 text-red-600 font-medium">
-                  This department has {deletingDepartment._count.users} users,{" "}
-                  {deletingDepartment._count.templates} templates, and{" "}
-                  {deletingDepartment._count.inspections} inspections and cannot be deleted.
+                  This department has {deletingDepartment._count.users} users, {" "}
+                  {deletingDepartment._count.templates} templates, and {deletingDepartment._count.inspections} inspections.
                 </span>
               )}
             </AlertDialogDescription>
@@ -209,7 +207,7 @@ export function DepartmentsList({ onUpdate }: DepartmentsListProps) {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
-              disabled={deletingDepartment ? !canDelete(deletingDepartment) : true}
+              disabled={!deletingDepartment}
               className="bg-red-600 hover:bg-red-700"
             >
               Delete

--- a/components/mini-admin/templates-list.tsx
+++ b/components/mini-admin/templates-list.tsx
@@ -111,8 +111,8 @@ export function TemplatesList({ onUpdate }: TemplatesListProps) {
     }
   }
 
-  const canDelete = (template: Template) => {
-    return template._count.inspections === 0
+  const canDelete = (_template: Template) => {
+    return true
   }
 
   if (loading) {
@@ -179,7 +179,6 @@ export function TemplatesList({ onUpdate }: TemplatesListProps) {
                     <DropdownMenuItem
                       className="text-red-600"
                       onClick={() => handleDelete(template)}
-                      disabled={!canDelete(template)}
                     >
                       <Trash2 className="mr-2 h-4 w-4" />
                       Delete
@@ -208,9 +207,9 @@ export function TemplatesList({ onUpdate }: TemplatesListProps) {
             <AlertDialogTitle>Delete Template</AlertDialogTitle>
             <AlertDialogDescription>
               Are you sure you want to delete "{deletingTemplate?.name}"? This action cannot be undone.
-              {deletingTemplate && !canDelete(deletingTemplate) && (
+              {deletingTemplate && (
                 <span className="block mt-2 text-red-600 font-medium">
-                  This template has {deletingTemplate._count.inspections} inspections and cannot be deleted.
+                  This template has {deletingTemplate._count.inspections} inspections.
                 </span>
               )}
             </AlertDialogDescription>
@@ -219,7 +218,7 @@ export function TemplatesList({ onUpdate }: TemplatesListProps) {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
-              disabled={deletingTemplate ? !canDelete(deletingTemplate) : true}
+              disabled={!deletingTemplate}
               className="bg-red-600 hover:bg-red-700"
             >
               Delete


### PR DESCRIPTION
## Summary
- permit deletion of areas, departments and templates even if they have members
- remove disabled delete buttons in admin and mini-admin lists
- skip check for existing associations in API routes

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_b_6858470a17f8832aaa0e1409a365deff