### PR TITLE
Enable super admin organization deletion

### DIFF
--- a/app/api/super-admin/organizations/[id]/route.ts
+++ b/app/api/super-admin/organizations/[id]/route.ts
@@ -40,15 +40,6 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 
-    // Check if organization has users
-    const userCount = await prisma.user.count({
-      where: { organizationId: params.id },
-    })
-
-    if (userCount > 0) {
-      return NextResponse.json({ error: "Cannot delete organization with existing users" }, { status: 400 })
-    }
-
     await prisma.organization.delete({
       where: { id: params.id },
     })

--- a/components/super-admin/organizations-list.tsx
+++ b/components/super-admin/organizations-list.tsx
@@ -175,7 +175,6 @@ export function OrganizationsList({ onUpdate }: OrganizationsListProps) {
                     <DropdownMenuItem
                       className="text-red-600"
                       onClick={() => handleDelete(org)}
-                      disabled={org._count.users > 0}
                     >
                       <Trash2 className="mr-2 h-4 w-4" />
                       Delete
@@ -214,9 +213,9 @@ export function OrganizationsList({ onUpdate }: OrganizationsListProps) {
             <AlertDialogTitle>Delete Organization</AlertDialogTitle>
             <AlertDialogDescription>
               Are you sure you want to delete "{deletingOrganization?.name}"? This action cannot be undone.
-              {deletingOrganization?._count?.users > 0 && (
+              {deletingOrganization && (
                 <span className="block mt-2 text-red-600 font-medium">
-                  This organization has {deletingOrganization?._count?.users} users and cannot be deleted.
+                  This organization has {deletingOrganization._count?.users} users.
                 </span>
               )}
             </AlertDialogDescription>
@@ -225,7 +224,7 @@ export function OrganizationsList({ onUpdate }: OrganizationsListProps) {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
-              disabled={deletingOrganization?._count.users > 0}
+              disabled={!deletingOrganization}
               className="bg-red-600 hover:bg-red-700"
             >
               Delete


### PR DESCRIPTION
## Summary
- allow super admins delete organizations that still have users
- remove UI restrictions for deleting organizations with users

## Testing
- `npm run lint` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685978cdce50832aa53d0ad5f65b19ef