### PR TITLE
Fix error messaging for user creation

### DIFF
--- a/components/admin/create-area-dialog.tsx
+++ b/components/admin/create-area-dialog.tsx
@@ -57,7 +57,7 @@ export function CreateAreaDialog({ open, onOpenChange, onSuccess }: CreateAreaDi
         const error = await response.json()
         toast({
           title: "Error",
-          description: error.message || "Failed to create area",
+          description: error.error || error.message || "Failed to create area",
           variant: "destructive",
         })
       }

--- a/components/admin/create-department-dialog.tsx
+++ b/components/admin/create-department-dialog.tsx
@@ -29,7 +29,7 @@ export function CreateDepartmentDialog({ open, onOpenChange, onSuccess }: Create
   const [formData, setFormData] = useState({
     departmentName: "",
     departmentDescription: "",
-    areaId: "",
+    areaId: "none",
   })
   const { toast } = useToast()
 
@@ -72,7 +72,7 @@ export function CreateDepartmentDialog({ open, onOpenChange, onSuccess }: Create
         setFormData({
           departmentName: "",
           departmentDescription: "",
-          areaId: "",
+          areaId: "none",
         })
         onOpenChange(false)
         onSuccess()
@@ -80,7 +80,7 @@ export function CreateDepartmentDialog({ open, onOpenChange, onSuccess }: Create
         const error = await response.json()
         toast({
           title: "Error",
-          description: error.message || "Failed to create department",
+          description: error.error || error.message || "Failed to create department",
           variant: "destructive",
         })
       }

--- a/components/admin/create-user-dialog.tsx
+++ b/components/admin/create-user-dialog.tsx
@@ -121,7 +121,7 @@ export function CreateUserDialog({ open, onOpenChange, onSuccess }: CreateUserDi
         const error = await response.json()
         toast({
           title: "Error",
-          description: error.message || "Failed to create user",
+          description: error.error || error.message || "Failed to create user",
           variant: "destructive",
         })
       }

--- a/components/mini-admin/create-user-dialog.tsx
+++ b/components/mini-admin/create-user-dialog.tsx
@@ -87,7 +87,7 @@ export function CreateUserDialog({ open, onOpenChange, onSuccess }: CreateUserDi
         const error = await response.json()
         toast({
           title: "Error",
-          description: error.message || "Failed to create user",
+          description: error.error || error.message || "Failed to create user",
           variant: "destructive",
         })
       }

--- a/components/mini-admin/edit-user-dialog.tsx
+++ b/components/mini-admin/edit-user-dialog.tsx
@@ -95,7 +95,7 @@ export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUser
         const error = await response.json()
         toast({
           title: "Error",
-          description: error.message || "Failed to update user",
+          description: error.error || error.message || "Failed to update user",
           variant: "destructive",
         })
       }


### PR DESCRIPTION
## Summary
- show backend error messages in user creation dialogs
- default admin department creation to 'No specific area'

## Testing
- `npm run lint` *(fails: ESLint configuration prompts without network access)*

------
https://chatgpt.com/codex/tasks/task_b_6859815000bc832a994997e741ad1e2f