### PR TITLE
Add JSON QR code endpoint for mini-admin

### DIFF
--- a/app/api/mini-admin/template-items/qr-codes/route.ts
+++ b/app/api/mini-admin/template-items/qr-codes/route.ts
@@ -24,6 +24,7 @@ export async function GET(request: NextRequest) {
 
     const { searchParams } = new URL(request.url)
     const templateId = searchParams.get("templateId")
+    const format = searchParams.get("format")
 
     if (!templateId) {
       return NextResponse.json({ message: "Template ID is required" }, { status: 400 })
@@ -39,6 +40,28 @@ export async function GET(request: NextRequest) {
 
     if (templateItems.length === 0) {
       return NextResponse.json({ message: "No template items found" }, { status: 404 })
+    }
+
+    if (format === "json") {
+      const itemsWithQR = await Promise.all(
+        templateItems.map(async (item) => {
+          const qrCodeUrl = await QRCode.toDataURL(item.qrCodeId, {
+            width: 300,
+            margin: 2,
+            color: {
+              dark: "#000000",
+              light: "#FFFFFF",
+            },
+          })
+
+          return {
+            ...item,
+            qrCodeUrl,
+          }
+        }),
+      )
+
+      return NextResponse.json(itemsWithQR)
     }
 
     // Create ZIP file with all QR codes

--- a/components/mini-admin/template-items-management.tsx
+++ b/components/mini-admin/template-items-management.tsx
@@ -123,7 +123,6 @@ export function MiniAdminTemplateItemsManagement({ templateId, templateName, onU
         onOpenChange={setShowQRDialog}
         templateId={templateId}
         templateName={templateName}
-        items={items}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- support JSON output for mini-admin QR code API
- fetch QR code JSON on dialog open
- show mini-admin QR codes like admin dialog
- prevent print page breaks on cards

## Testing
- `npm run lint` *(fails: requested setup via interactive prompt)*
- `npx tsc --noEmit` *(fails with existing type errors)*

------
https://chatgpt.com/codex/tasks/task_b_685c0a50bea0832aa0f539aed47d5850