### PR TITLE
Enable automatic dashboard refresh

### DIFF
--- a/components/admin/create-inspection-dialog.tsx
+++ b/components/admin/create-inspection-dialog.tsx
@@ -120,6 +120,7 @@ export function CreateInspectionDialog({ open, onOpenChange, onSuccess }: Create
         })
         onOpenChange(false)
         onSuccess()
+        window.dispatchEvent(new Event("inspection-created"))
       } else {
         const error = await response.json()
         toast({

--- a/components/inspector/dashboard.tsx
+++ b/components/inspector/dashboard.tsx
@@ -40,6 +40,13 @@ export function InspectorDashboard() {
 
   useEffect(() => {
     fetchInspections();
+    const interval = setInterval(fetchInspections, 30000);
+    const handleRefresh = () => fetchInspections();
+    window.addEventListener("inspection-created", handleRefresh);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("inspection-created", handleRefresh);
+    };
   }, []);
 
   const fetchInspections = async () => {

--- a/components/mini-admin/create-inspection-dialog.tsx
+++ b/components/mini-admin/create-inspection-dialog.tsx
@@ -120,6 +120,7 @@ export function CreateInspectionDialog({ open, onOpenChange, onSuccess }: Create
         })
         onOpenChange(false)
         onSuccess()
+        window.dispatchEvent(new Event("inspection-created"))
       } else {
         const error = await response.json()
         toast({


### PR DESCRIPTION
## Summary
- refresh inspector dashboard on a timer and when the create dialog signals completion
- emit `inspection-created` event after creating a new inspection

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_b_685c0a5e40c4832a9f54311e4b7517d3