### PR TITLE
Fix auth debug env

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -110,5 +110,5 @@ export const authOptions: NextAuthOptions = {
     signIn: "/auth/signin",
     error: "/auth/error",
   },
-  debug: process.env.NODE_ENV === "production",
+  debug: process.env.NODE_ENV === "development",
 }


### PR DESCRIPTION
## Summary
- enable NextAuth debug logs only in development

## Testing
- `pnpm build` *(fails: Failed to fetch font `Inter` and module not found)*
- `npx tsc --noEmit` *(fails to compile project types)*

------
https://chatgpt.com/codex/tasks/task_b_685c53b23c2c832a83d2524fd122b28a