### PR TITLE
Sync mini-admin template item fields

### DIFF
--- a/app/api/mini-admin/template-items/[id]/route.ts
+++ b/app/api/mini-admin/template-items/[id]/route.ts
@@ -40,19 +40,20 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       return NextResponse.json({ error: "Template item not found" }, { status: 404 })
     }
 
-    const { title, description, type, isRequired, expectedValue } = await request.json()
+    const { name, description, location } = await request.json()
 
-    // Generate new QR code ID if title changed
+    // Generate new QR code ID if name changed
     let qrCodeId = existingItem.qrCodeId
-    if (title !== existingItem.name) {
+    if (name !== existingItem.name) {
       qrCodeId = generateShortId()
     }
 
     const item = await prisma.checklistItem.update({
       where: { id: params.id },
       data: {
-        name: title, // Use 'name' field instead of 'title'
+        name,
         description,
+        location,
         qrCodeId,
       },
     })

--- a/app/api/mini-admin/template-items/route.ts
+++ b/app/api/mini-admin/template-items/route.ts
@@ -78,7 +78,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Area not found" }, { status: 400 })
     }
 
-    const { templateId, title, description } = await request.json()
+    const { templateId, name, description, location } = await request.json()
 
     // Verify template belongs to area
     const template = await prisma.masterTemplate.findFirst({
@@ -104,8 +104,9 @@ export async function POST(request: NextRequest) {
 
     const item = await prisma.checklistItem.create({
       data: {
-        name: title,
+        name,
         description,
+        location,
         order: nextOrder,
         qrCodeId,
         masterTemplateId: templateId,

--- a/components/mini-admin/create-template-item-dialog.tsx
+++ b/components/mini-admin/create-template-item-dialog.tsx
@@ -1,15 +1,12 @@
 "use client"
 
 import type React from "react"
-
 import { useState } from "react"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Checkbox } from "@/components/ui/checkbox"
 import { useToast } from "@/hooks/use-toast"
 import { Loader2 } from "lucide-react"
 
@@ -18,7 +15,12 @@ interface CreateTemplateItemDialogProps {
   onOpenChange: (open: boolean) => void
   templateId: string
   onSuccess: () => void
-  editItem?: any
+  editItem?: {
+    id: string
+    name: string
+    description?: string
+    location?: string
+  }
 }
 
 export function CreateTemplateItemDialog({
@@ -30,11 +32,9 @@ export function CreateTemplateItemDialog({
 }: CreateTemplateItemDialogProps) {
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState({
-    title: editItem?.title || "",
+    name: editItem?.name || "",
     description: editItem?.description || "",
-    type: editItem?.type || "CHECKBOX",
-    isRequired: editItem?.isRequired || true,
-    expectedValue: editItem?.expectedValue || "",
+    location: editItem?.location || "",
   })
   const { toast } = useToast()
 
@@ -44,7 +44,6 @@ export function CreateTemplateItemDialog({
 
     try {
       const url = editItem ? `/api/mini-admin/template-items/${editItem.id}` : `/api/mini-admin/template-items`
-
       const method = editItem ? "PUT" : "POST"
 
       const response = await fetch(url, {
@@ -63,13 +62,7 @@ export function CreateTemplateItemDialog({
           title: "Success",
           description: `Template item ${editItem ? "updated" : "created"} successfully.`,
         })
-        setFormData({
-          title: "",
-          description: "",
-          type: "CHECKBOX",
-          isRequired: true,
-          expectedValue: "",
-        })
+        setFormData({ name: "", description: "", location: "" })
         onOpenChange(false)
         onSuccess()
       } else {
@@ -93,24 +86,24 @@ export function CreateTemplateItemDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[500px]">
+      <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
-          <DialogTitle>{editItem ? "Edit" : "Create"} Template Item</DialogTitle>
+          <DialogTitle>{editItem ? "Edit" : "Add"} Template Item</DialogTitle>
           <DialogDescription>
-            {editItem ? "Update the" : "Add a new"} checklist item to this inspection template.
+            {editItem ? "Update the" : "Add a new"} checklist item to this template.
           </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="title">Item Title</Label>
+            <Label htmlFor="name">Item Name</Label>
             <Input
-              id="title"
-              value={formData.title}
-              onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-              placeholder="e.g., Check fire extinguisher pressure"
+              id="name"
+              value={formData.name}
+              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
               required
               disabled={loading}
+              placeholder="e.g., Check fire extinguisher"
             />
           </div>
 
@@ -120,59 +113,20 @@ export function CreateTemplateItemDialog({
               id="description"
               value={formData.description}
               onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-              placeholder="Additional instructions or details..."
               disabled={loading}
+              placeholder="Detailed instructions for this check"
             />
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="type">Item Type</Label>
-            <Select value={formData.type} onValueChange={(value) => setFormData({ ...formData, type: value })}>
-              <SelectTrigger>
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="CHECKBOX">Checkbox (Pass/Fail)</SelectItem>
-                <SelectItem value="TEXT">Text Input</SelectItem>
-                <SelectItem value="NUMBER">Number Input</SelectItem>
-                <SelectItem value="PHOTO">Photo Required</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          {formData.type === "TEXT" && (
-            <div className="space-y-2">
-              <Label htmlFor="expectedValue">Expected Value (Optional)</Label>
-              <Input
-                id="expectedValue"
-                value={formData.expectedValue}
-                onChange={(e) => setFormData({ ...formData, expectedValue: e.target.value })}
-                placeholder="Expected text value"
-                disabled={loading}
-              />
-            </div>
-          )}
-
-          {formData.type === "NUMBER" && (
-            <div className="space-y-2">
-              <Label htmlFor="expectedValue">Expected Range (Optional)</Label>
-              <Input
-                id="expectedValue"
-                value={formData.expectedValue}
-                onChange={(e) => setFormData({ ...formData, expectedValue: e.target.value })}
-                placeholder="e.g., 10-50 or >20"
-                disabled={loading}
-              />
-            </div>
-          )}
-
-          <div className="flex items-center space-x-2">
-            <Checkbox
-              id="isRequired"
-              checked={formData.isRequired}
-              onCheckedChange={(checked) => setFormData({ ...formData, isRequired: checked === true })}
+            <Label htmlFor="location">Location (Optional)</Label>
+            <Input
+              id="location"
+              value={formData.location}
+              onChange={(e) => setFormData({ ...formData, location: e.target.value })}
+              disabled={loading}
+              placeholder="e.g., Main hallway, Room 101"
             />
-            <Label htmlFor="isRequired">This item is required</Label>
           </div>
 
           <div className="flex justify-end space-x-2">
@@ -181,7 +135,7 @@ export function CreateTemplateItemDialog({
             </Button>
             <Button type="submit" disabled={loading}>
               {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {editItem ? "Update" : "Create"} Item
+              {editItem ? "Update" : "Add"} Item
             </Button>
           </div>
         </form>

--- a/components/mini-admin/template-items-list.tsx
+++ b/components/mini-admin/template-items-list.tsx
@@ -3,7 +3,6 @@
 import { useState } from "react"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { MoreHorizontal, Edit, Trash2, ChevronUp, ChevronDown, QrCode } from "lucide-react"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import {
@@ -22,13 +21,11 @@ import { useToast } from "@/hooks/use-toast"
 
 interface TemplateItem {
   id: string
-  name: string // Changed from 'title' to 'name'
+  name: string
   description?: string
-  type: string
-  isRequired: boolean
-  expectedValue?: string
+  location?: string
   order: number
-  qrCodeId: string // Use qrCodeId instead of qrCode
+  qrCodeId: string
 }
 
 interface TemplateItemsListProps {
@@ -129,35 +126,6 @@ export function TemplateItemsList({ templateId, items, onUpdate }: TemplateItems
     }
   }
 
-  const getTypeColor = (type: string) => {
-    switch (type) {
-      case "CHECKBOX":
-        return "bg-blue-100 text-blue-800"
-      case "TEXT":
-        return "bg-green-100 text-green-800"
-      case "NUMBER":
-        return "bg-purple-100 text-purple-800"
-      case "PHOTO":
-        return "bg-orange-100 text-orange-800"
-      default:
-        return "bg-gray-100 text-gray-800"
-    }
-  }
-
-  const getTypeLabel = (type: string) => {
-    switch (type) {
-      case "CHECKBOX":
-        return "Pass/Fail"
-      case "TEXT":
-        return "Text"
-      case "NUMBER":
-        return "Number"
-      case "PHOTO":
-        return "Photo"
-      default:
-        return type
-    }
-  }
 
   if (items.length === 0) {
     return (
@@ -174,12 +142,12 @@ export function TemplateItemsList({ templateId, items, onUpdate }: TemplateItems
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead className="w-[50px]">Order</TableHead>
-            <TableHead>Title</TableHead>
-            <TableHead>Type</TableHead>
-            <TableHead>Required</TableHead>
-            <TableHead>Expected Value</TableHead>
-            <TableHead className="w-[100px]">Actions</TableHead>
+            <TableHead className="w-[60px]">Order</TableHead>
+            <TableHead>Name</TableHead>
+            <TableHead>Description</TableHead>
+            <TableHead>Location</TableHead>
+            <TableHead>QR Code</TableHead>
+            <TableHead className="w-[120px]">Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -210,21 +178,18 @@ export function TemplateItemsList({ templateId, items, onUpdate }: TemplateItems
                   </div>
                 </div>
               </TableCell>
+              <TableCell className="font-medium">{item.name}</TableCell>
+              <TableCell>{item.description || "-"}</TableCell>
+              <TableCell>{item.location || "-"}</TableCell>
               <TableCell>
-                <div>
-                  <div className="font-medium">{item.name}</div> {/* Changed from item.title to item.name */}
-                  {item.description && <div className="text-sm text-gray-500 mt-1">{item.description}</div>}
-                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleDownloadQR(item.id, item.name)}
+                >
+                  <QrCode className="h-4 w-4" />
+                </Button>
               </TableCell>
-              <TableCell>
-                <Badge className={getTypeColor(item.type)}>{getTypeLabel(item.type)}</Badge>
-              </TableCell>
-              <TableCell>
-                <Badge variant={item.isRequired ? "default" : "secondary"}>
-                  {item.isRequired ? "Required" : "Optional"}
-                </Badge>
-              </TableCell>
-              <TableCell>{item.expectedValue || "-"}</TableCell>
               <TableCell>
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
@@ -233,10 +198,6 @@ export function TemplateItemsList({ templateId, items, onUpdate }: TemplateItems
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={() => handleDownloadQR(item.id, item.name)}>
-                      <QrCode className="mr-2 h-4 w-4" />
-                      Download QR
-                    </DropdownMenuItem>
                     <DropdownMenuItem onClick={() => setEditingItem(item)}>
                       <Edit className="mr-2 h-4 w-4" />
                       Edit


### PR DESCRIPTION
## Summary
- adjust mini-admin create item dialog to use `name`, `description`, and `location`
- simplify mini-admin template items list to match admin columns
- update mini-admin APIs to accept and return the new fields

## Testing
- `pnpm lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_b_685c5c583fa8832a9ace215ebc8b39e6