### PR TITLE
Address profile updates and email flow

### DIFF
--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -78,15 +78,20 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
     const emailChanged = email !== existingUser.email
 
+    const updateData: any = {
+      name,
+      email,
+      role: role as any,
+      areaId: areaId === "NONE" ? null : areaId,
+      departmentId: departmentId === "NONE" ? null : departmentId,
+    }
+    if (emailChanged) {
+      updateData.password = null
+    }
+
     const user = await prisma.user.update({
       where: { id: params.id },
-      data: {
-        name,
-        email,
-        role: role as any,
-        areaId: areaId === "NONE" ? null : areaId,
-        departmentId: departmentId === "NONE" ? null : departmentId,
-      },
+      data: updateData,
     })
 
     if (emailChanged) {

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -46,7 +46,10 @@ export async function PATCH(request: NextRequest) {
 
     // Only update profile image if provided
     if (profileImage !== undefined) {
-      updateData.profileImage = profileImage
+      updateData.image = profileImage
+    }
+    if (emailChanged) {
+      updateData.password = null
     }
 
     const updatedUser = await prisma.user.update({
@@ -59,7 +62,7 @@ export async function PATCH(request: NextRequest) {
         name: true,
         email: true,
         role: true,
-        profileImage: true,
+        image: true,
       },
     })
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -40,6 +40,7 @@ export default function ProfilePage() {
   const [formData, setFormData] = useState({
     name: session?.user?.name || "",
     email: session?.user?.email || "",
+    profileImage: session?.user?.profileImage || "",
   })
 
   useEffect(() => {
@@ -47,7 +48,9 @@ export default function ProfilePage() {
       setFormData({
         name: session.user?.name || "",
         email: session.user?.email || "",
+        profileImage: session.user?.profileImage || "",
       })
+      setProfileImage(session.user?.profileImage || null)
       fetchUserStats()
     }
   }, [session])
@@ -147,7 +150,9 @@ export default function ProfilePage() {
       // Create preview
       const reader = new FileReader()
       reader.onload = (e) => {
-        setProfileImage(e.target?.result as string)
+        const result = e.target?.result as string
+        setProfileImage(result)
+        setFormData((prev) => ({ ...prev, profileImage: result }))
       }
       reader.readAsDataURL(file)
 
@@ -183,18 +188,22 @@ export default function ProfilePage() {
       })
 
       if (!response.ok) {
-        throw new Error("Failed to update profile")
+        const err = await response.json()
+        throw new Error(err.error || "Failed to update profile")
       }
+      const updated = await response.json()
 
       // Update session data
       await update({
         ...session,
         user: {
           ...session.user,
-          name: formData.name,
-          email: formData.email,
+          name: updated.name,
+          email: updated.email,
+          profileImage: updated.image,
         },
       })
+      setProfileImage(updated.image || null)
 
       toast({
         title: "Profile updated",
@@ -202,9 +211,10 @@ export default function ProfilePage() {
       })
       setIsEditing(false)
     } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to update profile"
       toast({
         title: "Error",
-        description: "Failed to update profile. Please try again.",
+        description: message,
         variant: "destructive",
       })
     } finally {
@@ -216,7 +226,9 @@ export default function ProfilePage() {
     setFormData({
       name: session?.user?.name || "",
       email: session?.user?.email || "",
+      profileImage: session?.user?.profileImage || "",
     })
+    setProfileImage(session?.user?.profileImage || null)
     setIsEditing(false)
   }
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -51,7 +51,7 @@ export const authOptions: NextAuthOptions = {
           organizationId: user.organizationId,
           areaId: user.areaId,
           departmentId: user.departmentId,
-          profileImage: user.profileImage,
+          profileImage: user.image,
         }
       },
     }),
@@ -67,7 +67,7 @@ export const authOptions: NextAuthOptions = {
         token.organizationId = user.organizationId
         token.areaId = user.areaId
         token.departmentId = user.departmentId
-        token.profileImage = user.profileImage
+        token.profileImage = user.image
       }
 
       // Handle session updates

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -4,7 +4,7 @@ import { sendPasswordResetEmailFallback, sendWelcomeEmailFallback, sendAccountSe
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
   port: Number.parseInt(process.env.SMTP_PORT || "587"),
-  secure: false, // true for 465, false for other ports
+  secure: Number.parseInt(process.env.SMTP_PORT || "587") === 465,
   auth: {
     user: process.env.SMTP_USER,
     pass: process.env.SMTP_PASSWORD,
@@ -27,6 +27,7 @@ export async function sendPasswordResetEmail(email: string, resetToken: string) 
     from: process.env.SMTP_FROM,
     to: email,
     subject: "Reset Your Password - Inspection System",
+    text: `Reset your password using the following link: ${resetUrl}`,
     html: `
       <div style="max-width: 600px; margin: 0 auto; padding: 20px; font-family: Arial, sans-serif;">
         <h2>Password Reset Request</h2>
@@ -59,6 +60,7 @@ export async function sendWelcomeEmail(email: string, name: string, role: string
     from: process.env.SMTP_FROM,
     to: email,
     subject: "Welcome to Inspection System",
+    text: `Welcome to the Inspection System for ${organizationName}.`,
     html: `
       <div style="max-width: 600px; margin: 0 auto; padding: 20px; font-family: Arial, sans-serif;">
         <h2>Welcome to the Inspection System</h2>
@@ -97,6 +99,7 @@ export async function sendAccountSetupEmail(
     from: process.env.SMTP_FROM,
     to: email,
     subject: "Welcome to Inspection System",
+    text: `Create your password using the following link: ${resetUrl}`,
     html: `
       <div style="max-width: 600px; margin: 0 auto; padding: 20px; font-family: Arial, sans-serif;">
         <h2>Welcome to the Inspection System</h2>
@@ -131,6 +134,7 @@ export async function sendEmailUpdateNotification(email: string, resetToken: str
     from: process.env.SMTP_FROM,
     to: email,
     subject: "Your account email was updated",
+    text: `Your email was updated. Set a new password here: ${resetUrl}`,
     html: `
       <div style="max-width: 600px; margin: 0 auto; padding: 20px; font-family: Arial, sans-serif;">
         <h2>Email Updated</h2>


### PR DESCRIPTION
## Summary
- fix password reset flow when an email is changed
- store uploaded profile image and show updated state
- map profile image to the `image` column
- add plaintext to outgoing emails and use secure SMTP when needed

## Testing
- `pnpm lint` *(fails: ESLint requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_b_685d50df34b8832abf90c7d9e0dee030