### PR TITLE
Fix email update session handling

### DIFF
--- a/app/api/mini-admin/users/[id]/route.ts
+++ b/app/api/mini-admin/users/[id]/route.ts
@@ -65,14 +65,20 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
     const emailChanged = email !== existingUser.email
 
+    const updateData: any = {
+      name,
+      email,
+      role: role as any,
+      departmentId: departmentId || null,
+    }
+
+    if (emailChanged) {
+      updateData.password = null
+    }
+
     const user = await prisma.user.update({
       where: { id: params.id },
-      data: {
-        name,
-        email,
-        role: role as any,
-        departmentId: departmentId || null,
-      },
+      data: updateData,
     })
 
     if (emailChanged) {

--- a/app/api/super-admin/users/[id]/route.ts
+++ b/app/api/super-admin/users/[id]/route.ts
@@ -61,12 +61,18 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
     const emailChanged = email && email !== existingUser.email
 
+    const updateData: any = {
+      name,
+      email,
+    }
+
+    if (emailChanged) {
+      updateData.password = null
+    }
+
     const user = await prisma.user.update({
       where: { id: params.id },
-      data: {
-        name,
-        email,
-      },
+      data: updateData,
     })
 
     if (emailChanged) {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -67,7 +67,7 @@ export const authOptions: NextAuthOptions = {
         token.organizationId = user.organizationId
         token.areaId = user.areaId
         token.departmentId = user.departmentId
-        token.profileImage = user.image
+        token.profileImage = (user as any).profileImage ?? (user as any).image
       }
 
       // Handle session updates


### PR DESCRIPTION
## Summary
- reset passwords when admin email changes
- include profile images in auth token

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_b_685d57ae500c832ab18af60d5949a7e6