### PR TITLE
Fix email update warnings and restrict template management

### DIFF
--- a/app/api/admin/template-items/[id]/reorder/route.ts
+++ b/app/api/admin/template-items/[id]/reorder/route.ts
@@ -1,20 +1,24 @@
-import { type NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth/next"
-import type { Session } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { prisma } from "@/lib/prisma"
+import { type NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import type { Session } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 
-export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
   try {
-    const session: Session | null = await getServerSession(authOptions)
+    const session: Session | null = await getServerSession(authOptions);
 
     if (!session || session.user.role !== "ADMIN") {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const { direction } = await request.json()
+    const { direction } = await request.json();
 
-    const organizationId = session.user.organizationId
+    const organizationId = session.user.organizationId;
+    const userDepartmentId = session.user.departmentId;
 
     // Get the current item
     const currentItem = await prisma.checklistItem.findFirst({
@@ -22,41 +26,54 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
         id: params.id,
         masterTemplate: {
           organizationId,
+          ...(userDepartmentId ? { departmentId: userDepartmentId } : {}),
         },
       },
-    })
+    });
 
     if (!currentItem) {
-      return NextResponse.json({ error: "Template item not found" }, { status: 404 })
+      return NextResponse.json(
+        { error: "Template item not found" },
+        { status: 404 },
+      );
     }
 
     // Get all items for this template
     const allItems = await prisma.checklistItem.findMany({
       where: { masterTemplateId: currentItem.masterTemplateId },
       orderBy: { order: "asc" },
-    })
+    });
 
-    const currentIndex = allItems.findIndex((item) => item.id === params.id)
+    const currentIndex = allItems.findIndex((item) => item.id === params.id);
 
     if (currentIndex === -1) {
-      return NextResponse.json({ error: "Item not found in template" }, { status: 404 })
+      return NextResponse.json(
+        { error: "Item not found in template" },
+        { status: 404 },
+      );
     }
 
-    let targetIndex: number
+    let targetIndex: number;
     if (direction === "up") {
       if (currentIndex === 0) {
-        return NextResponse.json({ error: "Item is already at the top" }, { status: 400 })
+        return NextResponse.json(
+          { error: "Item is already at the top" },
+          { status: 400 },
+        );
       }
-      targetIndex = currentIndex - 1
+      targetIndex = currentIndex - 1;
     } else {
       if (currentIndex === allItems.length - 1) {
-        return NextResponse.json({ error: "Item is already at the bottom" }, { status: 400 })
+        return NextResponse.json(
+          { error: "Item is already at the bottom" },
+          { status: 400 },
+        );
       }
-      targetIndex = currentIndex + 1
+      targetIndex = currentIndex + 1;
     }
 
     // Swap the orders
-    const targetItem = allItems[targetIndex]
+    const targetItem = allItems[targetIndex];
 
     await prisma.$transaction([
       prisma.checklistItem.update({
@@ -67,14 +84,17 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
         where: { id: targetItem.id },
         data: { order: currentItem.order },
       }),
-    ])
+    ]);
 
     return NextResponse.json({
       message: "Items reordered successfully",
-    })
+    });
   } catch (error) {
-    console.error("Error reordering template items:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    console.error("Error reordering template items:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 

--- a/app/api/admin/template-items/[id]/route.ts
+++ b/app/api/admin/template-items/[id]/route.ts
@@ -1,52 +1,66 @@
-import { type NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth/next"
-import type { Session } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { prisma } from "@/lib/prisma"
+import { type NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import type { Session } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
 
-export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
   try {
-    const session: Session | null = await getServerSession(authOptions)
+    const session: Session | null = await getServerSession(authOptions);
 
     if (!session || session.user.role !== "ADMIN") {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const organizationId = session.user.organizationId
+    const organizationId = session.user.organizationId;
+    const userDepartmentId = session.user.departmentId;
 
-    // Verify item belongs to organization
+    // Verify item belongs to organization and department if restricted
     const item = await prisma.checklistItem.findFirst({
       where: {
         id: params.id,
         masterTemplate: {
           organizationId,
+          ...(userDepartmentId ? { departmentId: userDepartmentId } : {}),
         },
       },
-    })
+    });
 
     if (!item) {
-      return NextResponse.json({ error: "Template item not found" }, { status: 404 })
+      return NextResponse.json(
+        { error: "Template item not found" },
+        { status: 404 },
+      );
     }
 
     // Check if item has report results
     const reportCount = await prisma.reportItemResult.count({
       where: { checklistItemId: params.id },
-    })
+    });
 
     if (reportCount > 0) {
-      return NextResponse.json({ error: "Cannot delete item with existing inspection results" }, { status: 400 })
+      return NextResponse.json(
+        { error: "Cannot delete item with existing inspection results" },
+        { status: 400 },
+      );
     }
 
     await prisma.checklistItem.delete({
       where: { id: params.id },
-    })
+    });
 
     return NextResponse.json({
       message: "Template item deleted successfully",
-    })
+    });
   } catch (error) {
-    console.error("Error deleting template item:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    console.error("Error deleting template item:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 

--- a/app/api/admin/template-items/route.ts
+++ b/app/api/admin/template-items/route.ts
@@ -6,7 +6,8 @@ import { prisma } from "@/lib/prisma";
 import { randomBytes } from "crypto";
 
 function generateShortId(length = 8) {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   const bytes = randomBytes(length);
   let id = "";
   for (let i = 0; i < length; i++) {
@@ -34,11 +35,13 @@ export async function GET(request: NextRequest) {
     }
 
     const organizationId = session.user.organizationId;
+    const userDepartmentId = session.user.departmentId;
 
     const template = await prisma.masterTemplate.findFirst({
       where: {
         id: templateId,
         organizationId,
+        ...(userDepartmentId ? { departmentId: userDepartmentId } : {}),
       },
     });
 
@@ -79,11 +82,13 @@ export async function POST(request: NextRequest) {
     }
 
     const organizationId = session.user.organizationId;
+    const userDepartmentId = session.user.departmentId;
 
     const template = await prisma.masterTemplate.findFirst({
       where: {
         id: templateId,
         organizationId,
+        ...(userDepartmentId ? { departmentId: userDepartmentId } : {}),
       },
     });
 

--- a/app/api/admin/templates/[id]/route.ts
+++ b/app/api/admin/templates/[id]/route.ts
@@ -1,83 +1,130 @@
-import { type NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth/next"
-import type { Session } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { prisma } from "@/lib/prisma"
-import { createAuditLog } from "@/lib/audit"
+import { type NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import type { Session } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { createAuditLog } from "@/lib/audit";
 
-export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
   try {
-    const session: Session | null = await getServerSession(authOptions)
+    const session: Session | null = await getServerSession(authOptions);
 
     if (!session || session.user.role !== "ADMIN") {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const organizationId = session.user.organizationId
+    const organizationId = session.user.organizationId;
 
     if (!organizationId) {
-      return NextResponse.json({ error: "Organization not found" }, { status: 400 })
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 400 },
+      );
     }
 
-    // Verify template belongs to organization
+    const userDepartmentId = session.user.departmentId;
+
+    // Verify template belongs to organization (and department if restricted)
     const template = await prisma.masterTemplate.findFirst({
       where: {
         id: params.id,
         organizationId,
+        ...(userDepartmentId ? { departmentId: userDepartmentId } : {}),
       },
-    })
+    });
 
     if (!template) {
-      return NextResponse.json({ error: "Template not found" }, { status: 404 })
+      return NextResponse.json(
+        { error: "Template not found" },
+        { status: 404 },
+      );
     }
 
-    return NextResponse.json(template)
+    return NextResponse.json(template);
   } catch (error) {
-    console.error("Error fetching template:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    console.error("Error fetching template:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 
-export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
   try {
-    const session: Session | null = await getServerSession(authOptions)
+    const session: Session | null = await getServerSession(authOptions);
 
     if (!session || session.user.role !== "ADMIN") {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const organizationId = session.user.organizationId
+    const organizationId = session.user.organizationId;
 
     if (!organizationId) {
-      return NextResponse.json({ error: "Organization not found" }, { status: 400 })
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 400 },
+      );
     }
 
-    const { name, description, frequency, departmentId } = await request.json()
+    const { name, description, frequency, departmentId } = await request.json();
 
     // Verify template belongs to organization
+    const userDepartmentId = session.user.departmentId;
+
     const existingTemplate = await prisma.masterTemplate.findFirst({
       where: {
         id: params.id,
         organizationId,
+        ...(userDepartmentId ? { departmentId: userDepartmentId } : {}),
       },
-    })
+    });
 
     if (!existingTemplate) {
-      return NextResponse.json({ error: "Template not found" }, { status: 404 })
+      return NextResponse.json(
+        { error: "Template not found" },
+        { status: 404 },
+      );
     }
 
     // Verify department belongs to organization if provided
-    if (departmentId && departmentId !== "none") {
+    if (userDepartmentId) {
+      if (departmentId && departmentId !== userDepartmentId) {
+        return NextResponse.json(
+          { error: "Invalid department" },
+          { status: 400 },
+        );
+      }
+    } else if (departmentId && departmentId !== "none") {
       const department = await prisma.department.findFirst({
         where: {
           id: departmentId,
           organizationId,
         },
-      })
+      });
 
       if (!department) {
-        return NextResponse.json({ error: "Invalid department" }, { status: 400 })
+        return NextResponse.json(
+          { error: "Invalid department" },
+          { status: 400 },
+        );
       }
+    }
+
+    let finalDepartmentId: string | null = existingTemplate.departmentId;
+
+    if (userDepartmentId) {
+      finalDepartmentId = userDepartmentId;
+    } else if (departmentId && departmentId !== "none") {
+      finalDepartmentId = departmentId;
+    } else if (departmentId === "none") {
+      finalDepartmentId = null;
     }
 
     const template = await prisma.masterTemplate.update({
@@ -86,60 +133,88 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
         name,
         description,
         frequency,
-        departmentId: departmentId === "none" ? null : departmentId,
+        departmentId: finalDepartmentId,
       },
-    })
+    });
 
-    await createAuditLog(session.user.id, "UPDATE_TEMPLATE", "Template", params.id)
+    await createAuditLog(
+      session.user.id,
+      "UPDATE_TEMPLATE",
+      "Template",
+      params.id,
+    );
 
     return NextResponse.json({
       message: "Template updated successfully",
       template,
-    })
+    });
   } catch (error) {
-    console.error("Error updating template:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    console.error("Error updating template:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 
-export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
   try {
-    const session: Session | null = await getServerSession(authOptions)
+    const session: Session | null = await getServerSession(authOptions);
 
     if (!session || session.user.role !== "ADMIN") {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const organizationId = session.user.organizationId
+    const organizationId = session.user.organizationId;
 
     if (!organizationId) {
-      return NextResponse.json({ error: "Organization not found" }, { status: 400 })
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 400 },
+      );
     }
 
-    // Verify template belongs to organization
+    const userDepartmentId = session.user.departmentId;
+
+    // Verify template belongs to organization (and department if restricted)
     const existingTemplate = await prisma.masterTemplate.findFirst({
       where: {
         id: params.id,
         organizationId,
+        ...(userDepartmentId ? { departmentId: userDepartmentId } : {}),
       },
-    })
+    });
 
     if (!existingTemplate) {
-      return NextResponse.json({ error: "Template not found" }, { status: 404 })
+      return NextResponse.json(
+        { error: "Template not found" },
+        { status: 404 },
+      );
     }
 
     await prisma.masterTemplate.delete({
       where: { id: params.id },
-    })
+    });
 
-    await createAuditLog(session.user.id, "DELETE_TEMPLATE", "Template", params.id)
+    await createAuditLog(
+      session.user.id,
+      "DELETE_TEMPLATE",
+      "Template",
+      params.id,
+    );
 
     return NextResponse.json({
       message: "Template deleted successfully",
-    })
+    });
   } catch (error) {
-    console.error("Error deleting template:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    console.error("Error deleting template:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 

--- a/app/api/admin/templates/route.ts
+++ b/app/api/admin/templates/route.ts
@@ -1,26 +1,34 @@
-import { type NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth/next"
-import { authOptions } from "@/lib/auth"
-import type { Session } from "next-auth"
-import { prisma } from "@/lib/prisma"
-import { createAuditLog } from "@/lib/audit"
+import { type NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+import type { Session } from "next-auth";
+import { prisma } from "@/lib/prisma";
+import { createAuditLog } from "@/lib/audit";
 
 export async function GET() {
   try {
-    const session: Session | null = await getServerSession(authOptions)
+    const session: Session | null = await getServerSession(authOptions);
 
     if (!session || session.user.role !== "ADMIN") {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const organizationId = session.user.organizationId
+    const organizationId = session.user.organizationId;
 
     if (!organizationId) {
-      return NextResponse.json({ error: "Organization not found" }, { status: 400 })
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 400 },
+      );
     }
 
+    const userDepartmentId = session.user.departmentId;
+
     const templates = await prisma.masterTemplate.findMany({
-      where: { organizationId },
+      where: {
+        organizationId,
+        ...(userDepartmentId ? { departmentId: userDepartmentId } : {}),
+      },
       include: {
         department: {
           select: {
@@ -37,43 +45,63 @@ export async function GET() {
       orderBy: {
         createdAt: "desc",
       },
-    })
+    });
 
-    return NextResponse.json(templates)
+    return NextResponse.json(templates);
   } catch (error) {
-    console.error("Error fetching templates:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    console.error("Error fetching templates:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 
 export async function POST(request: NextRequest) {
   try {
-    const session: Session | null = await getServerSession(authOptions)
+    const session: Session | null = await getServerSession(authOptions);
 
     if (!session || session.user.role !== "ADMIN") {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const organizationId = session.user.organizationId
+    const organizationId = session.user.organizationId;
 
     if (!organizationId) {
-      return NextResponse.json({ error: "Organization not found" }, { status: 400 })
+      return NextResponse.json(
+        { error: "Organization not found" },
+        { status: 400 },
+      );
     }
 
-    const { name, description, frequency, departmentId } = await request.json()
+    const { name, description, frequency, departmentId } = await request.json();
 
-    // Verify department belongs to the organization if provided
-    if (departmentId && departmentId !== "none" && departmentId !== "") {
+    const userDepartmentId = session.user.departmentId;
+    let finalDepartmentId: string | null = null;
+
+    if (userDepartmentId) {
+      if (departmentId && departmentId !== userDepartmentId) {
+        return NextResponse.json(
+          { error: "Invalid department" },
+          { status: 400 },
+        );
+      }
+      finalDepartmentId = userDepartmentId;
+    } else if (departmentId && departmentId !== "none" && departmentId !== "") {
       const department = await prisma.department.findFirst({
         where: {
           id: departmentId,
           organizationId,
         },
-      })
+      });
 
       if (!department) {
-        return NextResponse.json({ error: "Invalid department" }, { status: 400 })
+        return NextResponse.json(
+          { error: "Invalid department" },
+          { status: 400 },
+        );
       }
+      finalDepartmentId = departmentId;
     }
 
     const template = await prisma.masterTemplate.create({
@@ -82,19 +110,27 @@ export async function POST(request: NextRequest) {
         description,
         frequency,
         organizationId,
-        departmentId: departmentId === "none" || departmentId === "" ? null : departmentId,
+        departmentId: finalDepartmentId,
       },
-    })
+    });
 
-    await createAuditLog(session.user.id, "CREATE_TEMPLATE", "Template", template.id)
+    await createAuditLog(
+      session.user.id,
+      "CREATE_TEMPLATE",
+      "Template",
+      template.id,
+    );
 
     return NextResponse.json({
       message: "Template created successfully",
       template,
-    })
+    });
   } catch (error) {
-    console.error("Error creating template:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    console.error("Error creating template:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 

--- a/app/api/mini-admin/templates/[id]/route.ts
+++ b/app/api/mini-admin/templates/[id]/route.ts
@@ -1,28 +1,42 @@
-import { type NextRequest, NextResponse } from "next/server"
-import { getServerSession } from "next-auth/next"
-import type { Session } from "next-auth"
-import { authOptions } from "@/lib/auth"
-import { prisma } from "@/lib/prisma"
-import { createAuditLog } from "@/lib/audit"
+import { type NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth/next";
+import type { Session } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { createAuditLog } from "@/lib/audit";
 
-export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
   try {
-    const session: Session | null = await getServerSession(authOptions)
+    const session: Session | null = await getServerSession(authOptions);
 
     if (!session || session.user.role !== "MINI_ADMIN") {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const areaId = session.user.areaId
+    const areaId = session.user.areaId;
+    const userDepartmentId = session.user.departmentId;
+    const userDepartmentId = session.user.departmentId;
 
     if (!areaId) {
-      return NextResponse.json({ error: "Area not found" }, { status: 400 })
+      return NextResponse.json({ error: "Area not found" }, { status: 400 });
     }
 
-    // Verify template belongs to area
+    // Verify template belongs to area and department if restricted
     const template = await prisma.masterTemplate.findFirst({
       where: {
         id: params.id,
+        OR: [
+          { departmentId: null },
+          {
+            department: {
+              areaId,
+              ...(userDepartmentId ? { id: userDepartmentId } : {}),
+            },
+          },
+        ],
       },
       select: {
         id: true,
@@ -31,70 +45,93 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
         frequency: true,
         createdAt: true,
       },
-    })
+    });
 
     if (!template) {
-      return NextResponse.json({ error: "Template not found" }, { status: 404 })
+      return NextResponse.json(
+        { error: "Template not found" },
+        { status: 404 },
+      );
     }
 
-    return NextResponse.json(template)
+    return NextResponse.json(template);
   } catch (error) {
-    console.error("Error fetching template:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    console.error("Error fetching template:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 
-export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
   try {
-    const session: Session | null = await getServerSession(authOptions)
+    const session: Session | null = await getServerSession(authOptions);
 
     if (!session || session.user.role !== "MINI_ADMIN") {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const areaId = session.user.areaId
+    const areaId = session.user.areaId;
 
     if (!areaId) {
-      return NextResponse.json({ error: "Area not found" }, { status: 400 })
+      return NextResponse.json({ error: "Area not found" }, { status: 400 });
     }
 
-    const body = await request.json()
-    const { name, description, departmentId } = body
+    const body = await request.json();
+    const { name, description, departmentId } = body;
 
     if (!name) {
-      return NextResponse.json({ error: "Name is required" }, { status: 400 })
+      return NextResponse.json({ error: "Name is required" }, { status: 400 });
     }
 
-    // Verify template exists and belongs to area (through department)
+    // Verify template exists and belongs to area (and department if restricted)
     const existingTemplate = await prisma.masterTemplate.findFirst({
       where: {
         id: params.id,
         OR: [
-          { departmentId: null }, // Global templates
+          { departmentId: null },
           {
             department: {
-              areaId: areaId,
+              areaId,
+              ...(userDepartmentId ? { id: userDepartmentId } : {}),
             },
           },
         ],
       },
-    })
+    });
 
     if (!existingTemplate) {
-      return NextResponse.json({ error: "Template not found" }, { status: 404 })
+      return NextResponse.json(
+        { error: "Template not found" },
+        { status: 404 },
+      );
     }
 
     // If departmentId is provided, verify it belongs to the area
-    if (departmentId && departmentId !== "none") {
+    if (userDepartmentId) {
+      if (departmentId && departmentId !== userDepartmentId) {
+        return NextResponse.json(
+          { error: "Department not found in your area" },
+          { status: 400 },
+        );
+      }
+    } else if (departmentId && departmentId !== "none") {
       const department = await prisma.department.findFirst({
         where: {
           id: departmentId,
-          areaId: areaId,
+          areaId,
         },
-      })
+      });
 
       if (!department) {
-        return NextResponse.json({ error: "Department not found in your area" }, { status: 400 })
+        return NextResponse.json(
+          { error: "Department not found in your area" },
+          { status: 400 },
+        );
       }
     }
 
@@ -103,7 +140,11 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       data: {
         name,
         description: description || null,
-        departmentId: departmentId === "none" || !departmentId ? null : departmentId,
+        departmentId: userDepartmentId
+          ? userDepartmentId
+          : departmentId === "none" || !departmentId
+            ? null
+            : departmentId,
       },
       include: {
         department: {
@@ -119,29 +160,40 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
           },
         },
       },
-    })
+    });
 
-    await createAuditLog(session.user.id, "UPDATE_TEMPLATE", "Template", params.id)
+    await createAuditLog(
+      session.user.id,
+      "UPDATE_TEMPLATE",
+      "Template",
+      params.id,
+    );
 
-    return NextResponse.json(updatedTemplate)
+    return NextResponse.json(updatedTemplate);
   } catch (error) {
-    console.error("Error updating template:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    console.error("Error updating template:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 
-export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
   try {
-    const session: Session | null = await getServerSession(authOptions)
+    const session: Session | null = await getServerSession(authOptions);
 
     if (!session || session.user.role !== "MINI_ADMIN") {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const areaId = session.user.areaId
+    const areaId = session.user.areaId;
 
     if (!areaId) {
-      return NextResponse.json({ error: "Area not found" }, { status: 400 })
+      return NextResponse.json({ error: "Area not found" }, { status: 400 });
     }
 
     const existingTemplate = await prisma.masterTemplate.findFirst({
@@ -149,20 +201,31 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
         id: params.id,
         department: { areaId },
       },
-    })
+    });
 
     if (!existingTemplate) {
-      return NextResponse.json({ error: "Template not found" }, { status: 404 })
+      return NextResponse.json(
+        { error: "Template not found" },
+        { status: 404 },
+      );
     }
 
-    await prisma.masterTemplate.delete({ where: { id: params.id } })
+    await prisma.masterTemplate.delete({ where: { id: params.id } });
 
-    await createAuditLog(session.user.id, "DELETE_TEMPLATE", "Template", params.id)
+    await createAuditLog(
+      session.user.id,
+      "DELETE_TEMPLATE",
+      "Template",
+      params.id,
+    );
 
-    return NextResponse.json({ message: "Template deleted" })
+    return NextResponse.json({ message: "Template deleted" });
   } catch (error) {
-    console.error("Error deleting template:", error)
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+    console.error("Error deleting template:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
   }
 }
 

--- a/components/admin/edit-user-dialog.tsx
+++ b/components/admin/edit-user-dialog.tsx
@@ -1,103 +1,119 @@
-"use client"
+"use client";
 
-import type React from "react"
+import type React from "react";
 
-import { useState, useEffect } from "react"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { useToast } from "@/hooks/use-toast"
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
 
 interface User {
-  id: string
-  name?: string
-  email: string
-  role: string
-  areaId?: string
-  departmentId?: string
+  id: string;
+  name?: string;
+  email: string;
+  role: string;
+  areaId?: string;
+  departmentId?: string;
   area?: {
-    id: string
-    name: string
-  }
+    id: string;
+    name: string;
+  };
   department?: {
-    id: string
-    name: string
-  }
+    id: string;
+    name: string;
+  };
 }
 
 interface Area {
-  id: string
-  name: string
+  id: string;
+  name: string;
 }
 
 interface Department {
-  id: string
-  name: string
-  areaId?: string
+  id: string;
+  name: string;
+  areaId?: string;
 }
 
 interface EditUserDialogProps {
-  user: User | null
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  onSuccess: () => void
+  user: User | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
 }
 
-export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUserDialogProps) {
-  const [name, setName] = useState("")
-  const [email, setEmail] = useState("")
-  const [role, setRole] = useState("")
-  const [areaId, setAreaId] = useState("")
-  const [departmentId, setDepartmentId] = useState("")
-  const [areas, setAreas] = useState<Area[]>([])
-  const [departments, setDepartments] = useState<Department[]>([])
-  const [loading, setLoading] = useState(false)
-  const [loadingData, setLoadingData] = useState(false)
-  const { toast } = useToast()
+export function EditUserDialog({
+  user,
+  open,
+  onOpenChange,
+  onSuccess,
+}: EditUserDialogProps) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [role, setRole] = useState("");
+  const [areaId, setAreaId] = useState("");
+  const [departmentId, setDepartmentId] = useState("");
+  const [areas, setAreas] = useState<Area[]>([]);
+  const [departments, setDepartments] = useState<Department[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loadingData, setLoadingData] = useState(false);
+  const { toast } = useToast();
 
   useEffect(() => {
     if (open && user) {
-      setName(user.name || "")
-      setEmail(user.email)
-      setRole(user.role)
-      setAreaId(user.areaId || "NONE")
-      setDepartmentId(user.departmentId || "NONE")
-      fetchAreas()
-      fetchDepartments()
+      setName(user.name || "");
+      setEmail(user.email);
+      setRole(user.role);
+      setAreaId(user.areaId || "NONE");
+      setDepartmentId(user.departmentId || "NONE");
+      fetchAreas();
+      fetchDepartments();
     }
-  }, [open, user])
+  }, [open, user]);
 
   const fetchAreas = async () => {
     try {
-      const response = await fetch("/api/admin/areas")
+      const response = await fetch("/api/admin/areas");
       if (response.ok) {
-        const data = await response.json()
-        setAreas(data)
+        const data = await response.json();
+        setAreas(data);
       }
     } catch (error) {
-      console.error("Failed to fetch areas:", error)
+      console.error("Failed to fetch areas:", error);
     }
-  }
+  };
 
   const fetchDepartments = async () => {
     try {
-      const response = await fetch("/api/admin/departments")
+      const response = await fetch("/api/admin/departments");
       if (response.ok) {
-        const data = await response.json()
-        setDepartments(data)
+        const data = await response.json();
+        setDepartments(data);
       }
     } catch (error) {
-      console.error("Failed to fetch departments:", error)
+      console.error("Failed to fetch departments:", error);
     }
-  }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!user) return
+    e.preventDefault();
+    if (!user) return;
 
-    setLoading(true)
+    setLoading(true);
     try {
       const response = await fetch(`/api/admin/users/${user.id}`, {
         method: "PUT",
@@ -111,46 +127,46 @@ export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUser
           areaId: areaId === "NONE" ? null : areaId,
           departmentId: departmentId === "NONE" ? null : departmentId,
         }),
-      })
+      });
 
       if (response.ok) {
         toast({
           title: "Success",
           description: "User updated successfully.",
-        })
-        onSuccess()
-        onOpenChange(false)
+        });
+        onSuccess();
+        onOpenChange(false);
       } else {
-        const error = await response.json()
+        const error = await response.json();
         toast({
           title: "Error",
-          description: error.message || "Failed to update user",
+          description: error.error || error.message || "Failed to update user",
           variant: "destructive",
-        })
+        });
       }
     } catch (error) {
       toast({
         title: "Error",
         description: "An unexpected error occurred",
         variant: "destructive",
-      })
+      });
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   const getRoleDisplay = (role: string) => {
     switch (role) {
       case "ADMIN":
-        return "Team Leader"
+        return "Team Leader";
       case "MINI_ADMIN":
-        return "Area Leader"
+        return "Area Leader";
       case "INSPECTOR":
-        return "Inspector"
+        return "Inspector";
       default:
-        return role
+        return role;
     }
-  }
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -161,7 +177,12 @@ export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUser
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
             <Label htmlFor="name">Name (Optional)</Label>
-            <Input id="name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Enter user name" />
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Enter user name"
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="email">Email *</Label>
@@ -182,8 +203,12 @@ export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUser
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="ADMIN">{getRoleDisplay("ADMIN")}</SelectItem>
-                <SelectItem value="MINI_ADMIN">{getRoleDisplay("MINI_ADMIN")}</SelectItem>
-                <SelectItem value="INSPECTOR">{getRoleDisplay("INSPECTOR")}</SelectItem>
+                <SelectItem value="MINI_ADMIN">
+                  {getRoleDisplay("MINI_ADMIN")}
+                </SelectItem>
+                <SelectItem value="INSPECTOR">
+                  {getRoleDisplay("INSPECTOR")}
+                </SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -220,7 +245,11 @@ export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUser
             </Select>
           </div>
           <div className="flex justify-end space-x-2">
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+            >
               Cancel
             </Button>
             <Button type="submit" disabled={loading}>
@@ -230,5 +259,5 @@ export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUser
         </form>
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/components/admin/template-items-list.tsx
+++ b/components/admin/template-items-list.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import { useState, useEffect } from "react";
 import {
@@ -36,97 +36,108 @@ interface TemplateItem {
 }
 
 interface TemplateItemsListProps {
-  templateId: string
-  onUpdate: () => void
-  onShowQR: (item: TemplateItem) => void
+  templateId: string;
+  refreshKey: number;
+  onUpdate: () => void;
+  onShowQR: (item: TemplateItem) => void;
 }
 
-export function TemplateItemsList({ templateId, onUpdate, onShowQR }: TemplateItemsListProps) {
-  const [items, setItems] = useState<TemplateItem[]>([])
-  const [loading, setLoading] = useState(true)
-  const { toast } = useToast()
+export function TemplateItemsList({
+  templateId,
+  refreshKey,
+  onUpdate,
+  onShowQR,
+}: TemplateItemsListProps) {
+  const [items, setItems] = useState<TemplateItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { toast } = useToast();
 
   useEffect(() => {
-    fetchItems()
-  }, [templateId])
+    fetchItems();
+  }, [templateId, refreshKey]);
 
   const fetchItems = async () => {
     try {
-      const response = await fetch(`/api/admin/template-items?templateId=${templateId}`)
+      const response = await fetch(
+        `/api/admin/template-items?templateId=${templateId}`,
+      );
       if (response.ok) {
-        const data = await response.json()
-        setItems(data)
+        const data = await response.json();
+        setItems(data);
       }
     } catch (error) {
-      console.error("Failed to fetch template items:", error)
+      console.error("Failed to fetch template items:", error);
     } finally {
-      setLoading(false)
+      setLoading(false);
     }
-  }
+  };
 
   const handleReorder = async (itemId: string, direction: "up" | "down") => {
     try {
-      const response = await fetch(`/api/admin/template-items/${itemId}/reorder`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await fetch(
+        `/api/admin/template-items/${itemId}/reorder`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ direction }),
         },
-        body: JSON.stringify({ direction }),
-      })
+      );
 
       if (response.ok) {
-        fetchItems()
-        onUpdate()
+        fetchItems();
+        onUpdate();
       } else {
         toast({
           title: "Error",
           description: "Failed to reorder item",
           variant: "destructive",
-        })
+        });
       }
     } catch (error) {
       toast({
         title: "Error",
         description: "An unexpected error occurred",
         variant: "destructive",
-      })
+      });
     }
-  }
+  };
 
   const handleDelete = async (itemId: string) => {
-    if (!confirm("Are you sure you want to delete this item?")) return
+    if (!confirm("Are you sure you want to delete this item?")) return;
 
     try {
       const response = await fetch(`/api/admin/template-items/${itemId}`, {
         method: "DELETE",
-      })
+      });
 
       if (response.ok) {
         toast({
           title: "Success",
           description: "Template item deleted successfully.",
-        })
-        fetchItems()
-        onUpdate()
+        });
+        fetchItems();
+        onUpdate();
       } else {
-        const error = await response.json()
+        const error = await response.json();
         toast({
           title: "Error",
           description: error.message || "Failed to delete template item",
           variant: "destructive",
-        })
+        });
       }
     } catch (error) {
       toast({
         title: "Error",
         description: "An unexpected error occurred",
         variant: "destructive",
-      })
+      });
     }
-  }
+  };
 
   if (loading) {
-    return <div className="text-center py-4">Loading template items...</div>
+    return <div className="text-center py-4">Loading template items...</div>;
   }
 
   if (items.length === 0) {
@@ -134,7 +145,7 @@ export function TemplateItemsList({ templateId, onUpdate, onShowQR }: TemplateIt
       <div className="text-center py-8 text-gray-500">
         No template items found. Add your first checklist item to get started.
       </div>
-    )
+    );
   }
 
   const sortedItems = [...items].sort((a, b) => a.order - b.order);
@@ -183,7 +194,11 @@ export function TemplateItemsList({ templateId, onUpdate, onShowQR }: TemplateIt
             <TableCell>{item.description || "-"}</TableCell>
             <TableCell>{item.location || "-"}</TableCell>
             <TableCell>
-              <Button variant="outline" size="sm" onClick={() => onShowQR(item)}>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onShowQR(item)}
+              >
                 <QrCode className="h-4 w-4" />
               </Button>
             </TableCell>
@@ -199,7 +214,10 @@ export function TemplateItemsList({ templateId, onUpdate, onShowQR }: TemplateIt
                     <Edit className="mr-2 h-4 w-4" />
                     Edit
                   </DropdownMenuItem>
-                  <DropdownMenuItem className="text-red-600" onClick={() => handleDelete(item.id)}>
+                  <DropdownMenuItem
+                    className="text-red-600"
+                    onClick={() => handleDelete(item.id)}
+                  >
                     <Trash2 className="mr-2 h-4 w-4" />
                     Delete
                   </DropdownMenuItem>
@@ -210,5 +228,5 @@ export function TemplateItemsList({ templateId, onUpdate, onShowQR }: TemplateIt
         ))}
       </TableBody>
     </Table>
-  )
+  );
 }

--- a/components/admin/template-items-management.tsx
+++ b/components/admin/template-items-management.tsx
@@ -1,28 +1,39 @@
-"use client"
+"use client";
 
-import { useState } from "react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { Plus, QrCode } from "lucide-react"
-import { CreateTemplateItemDialog } from "./create-template-item-dialog"
-import { TemplateItemsList } from "./template-items-list"
-import { QRCodeDialog } from "./qr-code-dialog"
+import { useState } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Plus, QrCode } from "lucide-react";
+import { CreateTemplateItemDialog } from "./create-template-item-dialog";
+import { TemplateItemsList } from "./template-items-list";
+import { QRCodeDialog } from "./qr-code-dialog";
 
 interface TemplateItemsManagementProps {
-  templateId: string
-  templateName: string
-  onUpdate: () => void
+  templateId: string;
+  templateName: string;
+  onUpdate: () => void;
 }
 
-export function TemplateItemsManagement({ templateId, templateName, onUpdate }: TemplateItemsManagementProps) {
-  const [showCreateDialog, setShowCreateDialog] = useState(false)
-  const [showQRDialog, setShowQRDialog] = useState(false)
-  const [selectedItem, setSelectedItem] = useState<any>(null)
+export function TemplateItemsManagement({
+  templateId,
+  templateName,
+  onUpdate,
+}: TemplateItemsManagementProps) {
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [showQRDialog, setShowQRDialog] = useState(false);
+  const [selectedItem, setSelectedItem] = useState<any>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
 
   const handleShowQR = (item: any) => {
-    setSelectedItem(item)
-    setShowQRDialog(true)
-  }
+    setSelectedItem(item);
+    setShowQRDialog(true);
+  };
 
   return (
     <Card>
@@ -30,14 +41,23 @@ export function TemplateItemsManagement({ templateId, templateName, onUpdate }: 
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
             <CardTitle>Template Items - {templateName}</CardTitle>
-            <CardDescription>Manage checklist items for this inspection template</CardDescription>
+            <CardDescription>
+              Manage checklist items for this inspection template
+            </CardDescription>
           </div>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 w-full sm:w-auto sm:block">
-            <Button variant="outline" onClick={() => setShowQRDialog(true)} className="w-full sm:w-auto">
+            <Button
+              variant="outline"
+              onClick={() => setShowQRDialog(true)}
+              className="w-full sm:w-auto"
+            >
               <QrCode className="mr-2 h-4 w-4" />
               View QR Codes
             </Button>
-            <Button onClick={() => setShowCreateDialog(true)} className="w-full sm:w-auto">
+            <Button
+              onClick={() => setShowCreateDialog(true)}
+              className="w-full sm:w-auto"
+            >
               <Plus className="mr-2 h-4 w-4" />
               Add Item
             </Button>
@@ -45,13 +65,24 @@ export function TemplateItemsManagement({ templateId, templateName, onUpdate }: 
         </div>
       </CardHeader>
       <CardContent className="overflow-auto">
-        <TemplateItemsList templateId={templateId} onUpdate={onUpdate} onShowQR={handleShowQR} />
+        <TemplateItemsList
+          templateId={templateId}
+          refreshKey={refreshKey}
+          onUpdate={() => {
+            setRefreshKey((k) => k + 1);
+            onUpdate();
+          }}
+          onShowQR={handleShowQR}
+        />
       </CardContent>
 
       <CreateTemplateItemDialog
         open={showCreateDialog}
         onOpenChange={setShowCreateDialog}
-        onSuccess={onUpdate}
+        onSuccess={() => {
+          setRefreshKey((k) => k + 1);
+          onUpdate();
+        }}
         templateId={templateId}
       />
 
@@ -62,5 +93,5 @@ export function TemplateItemsManagement({ templateId, templateName, onUpdate }: 
         selectedItem={selectedItem}
       />
     </Card>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- show server error message when editing users fails
- refresh template item list after creating items
- allow template items list to refresh via prop
- restrict template and item APIs by user's department for admins and area leaders

## Testing
- `pnpm lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_685d5c411878832a9e27b8df6efdcdde