### PR TITLE
Implement password management and flexible inspections

### DIFF
--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -6,6 +6,7 @@ import { prisma } from "@/lib/prisma"
 import { sendEmailUpdateNotification } from "@/lib/email"
 import { generateResetToken } from "@/lib/utils"
 import { createAuditLog } from "@/lib/audit"
+import bcrypt from "bcryptjs"
 
 export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -21,7 +22,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       return NextResponse.json({ error: "Organization not found" }, { status: 400 })
     }
 
-    const { name, email, role, areaId, departmentId } = await request.json()
+    const { name, email, role, areaId, departmentId, password } = await request.json()
 
     // Verify user belongs to organization
     const existingUser = await prisma.user.findFirst({
@@ -78,6 +79,17 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
     const emailChanged = email !== existingUser.email
 
+    const roleLevel: Record<string, number> = {
+      SUPER_ADMIN: 3,
+      ADMIN: 2,
+      MINI_ADMIN: 1,
+      INSPECTOR: 0,
+    }
+
+    if (roleLevel[existingUser.role] > roleLevel[session.user.role]) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+
     const updateData: any = {
       name,
       email,
@@ -87,6 +99,9 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
     }
     if (emailChanged) {
       updateData.password = null
+    }
+    if (password) {
+      updateData.password = await bcrypt.hash(password, 12)
     }
 
     const user = await prisma.user.update({

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -62,7 +62,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Organization not found" }, { status: 400 })
     }
 
-    const { name, email, role, areaId, departmentId } = await request.json()
+    const { name, email, role, areaId, departmentId, password } = await request.json()
 
     // Check if email already exists (case-insensitive)
     const existingUser = await prisma.user.findFirst({
@@ -102,10 +102,16 @@ export async function POST(request: NextRequest) {
 
     // Create user in a transaction
     const result = await prisma.$transaction(async (tx) => {
-      // Generate temporary password and reset token
-      const tempPassword = Math.random().toString(36).slice(-8)
-      const hashedPassword = await bcrypt.hash(tempPassword, 12)
-      const resetToken = generateResetToken()
+      let hashedPassword: string
+      let resetToken: string | null = null
+
+      if (password) {
+        hashedPassword = await bcrypt.hash(password, 12)
+      } else {
+        const tempPassword = Math.random().toString(36).slice(-8)
+        hashedPassword = await bcrypt.hash(tempPassword, 12)
+        resetToken = generateResetToken()
+      }
 
       // Create user
       const user = await tx.user.create({
@@ -120,14 +126,15 @@ export async function POST(request: NextRequest) {
         },
       })
 
-      // Store reset token
-      await tx.verificationToken.create({
-        data: {
-          identifier: email,
-          token: resetToken,
-          expires: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24 hours
-        },
-      })
+      if (resetToken) {
+        await tx.verificationToken.create({
+          data: {
+            identifier: email,
+            token: resetToken,
+            expires: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          },
+        })
+      }
 
       return { user, resetToken }
     })
@@ -139,13 +146,15 @@ export async function POST(request: NextRequest) {
     })
 
     // Send account setup email
-    await sendAccountSetupEmail(
-      email,
-      name,
-      role,
-      organization?.name || "Organization",
-      result.resetToken,
-    )
+    if (result.resetToken) {
+      await sendAccountSetupEmail(
+        email,
+        name,
+        role,
+        organization?.name || "Organization",
+        result.resetToken,
+      )
+    }
 
     await createAuditLog(session.user.id, "CREATE_USER", "User", result.user.id)
 

--- a/app/api/inspector/inspections/route.ts
+++ b/app/api/inspector/inspections/route.ts
@@ -8,14 +8,21 @@ export async function GET() {
   try {
     const session: Session | null = await getServerSession(authOptions)
 
-    if (!session || session.user.role !== "INSPECTOR") {
+    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 
+    let where: any = {}
+    if (session.user.role === "INSPECTOR") {
+      where = { departmentId: session.user.departmentId }
+    } else if (session.user.role === "MINI_ADMIN") {
+      where = { department: { areaId: session.user.areaId } }
+    } else {
+      where = { department: { organizationId: session.user.organizationId } }
+    }
+
     const inspections = await prisma.inspectionInstance.findMany({
-      where: {
-        inspectorId: session.user.id,
-      },
+      where,
       include: {
         masterTemplate: {
           select: {

--- a/app/api/mini-admin/inspections/[id]/route.ts
+++ b/app/api/mini-admin/inspections/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server"
+import { getServerSession } from "next-auth/next"
+import type { Session } from "next-auth"
+import { authOptions } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  try {
+    const session: Session | null = await getServerSession(authOptions)
+
+    if (!session || session.user.role !== "MINI_ADMIN") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const areaId = session.user.areaId
+    if (!areaId) {
+      return NextResponse.json({ error: "Area not found" }, { status: 400 })
+    }
+
+    const inspection = await prisma.inspectionInstance.findFirst({
+      where: { id: params.id, department: { areaId } },
+      include: { report: { include: { reportItems: true } } },
+    })
+
+    if (!inspection) {
+      return NextResponse.json({ error: "Inspection not found" }, { status: 404 })
+    }
+
+    if (inspection.status !== "PENDING" || (inspection.report && inspection.report.reportItems.length > 0)) {
+      return NextResponse.json({ error: "Cannot delete inspection that has started" }, { status: 400 })
+    }
+
+    await prisma.inspectionInstance.delete({ where: { id: params.id } })
+
+    return NextResponse.json({ message: "Inspection deleted" })
+  } catch (error) {
+    console.error("Error deleting inspection:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}
+
+export const dynamic = "force-dynamic"

--- a/app/api/super-admin/users/[id]/route.ts
+++ b/app/api/super-admin/users/[id]/route.ts
@@ -5,6 +5,7 @@ import { authOptions } from "@/lib/auth"
 import { prisma } from "@/lib/prisma"
 import { sendEmailUpdateNotification } from "@/lib/email"
 import { generateResetToken } from "@/lib/utils"
+import bcrypt from "bcryptjs"
 
 export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -38,7 +39,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 
-    const { name, email } = await request.json()
+    const { name, email, password } = await request.json()
 
     const existingUser = await prisma.user.findUnique({ where: { id: params.id } })
 
@@ -68,6 +69,9 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
     if (emailChanged) {
       updateData.password = null
+    }
+    if (password) {
+      updateData.password = await bcrypt.hash(password, 12)
     }
 
     const user = await prisma.user.update({

--- a/app/inspector/inspection/[id]/page.tsx
+++ b/app/inspector/inspection/[id]/page.tsx
@@ -13,7 +13,7 @@ interface InspectionPageProps {
 export default async function InspectionPage({ params }: InspectionPageProps) {
   const session: Session | null = await getServerSession(authOptions)
 
-  if (!session || session.user.role !== "INSPECTOR") {
+  if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
     redirect("/auth/signin")
   }
 

--- a/app/inspector/inspections/page.tsx
+++ b/app/inspector/inspections/page.tsx
@@ -7,7 +7,7 @@ import { InspectionsList } from "@/components/inspector/inspections-list"
 export default async function InspectionsPage() {
   const session: Session | null = await getServerSession(authOptions)
 
-  if (!session || session.user.role !== "INSPECTOR") {
+  if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
     redirect("/auth/signin")
   }
 

--- a/app/inspector/page.tsx
+++ b/app/inspector/page.tsx
@@ -7,7 +7,7 @@ import { InspectorDashboard } from "@/components/inspector/dashboard"
 export default async function InspectorPage() {
   const session: Session | null = await getServerSession(authOptions)
 
-  if (!session || session.user.role !== "INSPECTOR") {
+  if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
     redirect("/auth/signin")
   }
 

--- a/components/admin/create-user-dialog.tsx
+++ b/components/admin/create-user-dialog.tsx
@@ -36,6 +36,7 @@ export function CreateUserDialog({ open, onOpenChange, onSuccess }: CreateUserDi
   const [formData, setFormData] = useState({
     name: "",
     email: "",
+    password: "",
     role: "INSPECTOR",
     areaId: "",
     departmentId: "",
@@ -100,17 +101,21 @@ export function CreateUserDialog({ open, onOpenChange, onSuccess }: CreateUserDi
             formData.departmentId === "" || formData.departmentId === "none"
               ? "NONE"
               : formData.departmentId,
+          password: formData.password || undefined,
         }),
       })
 
       if (response.ok) {
         toast({
           title: "Success",
-          description: "User created successfully. They will receive an email to set their password.",
+          description: formData.password
+            ? "User created successfully."
+            : "User created successfully. They will receive an email to set their password.",
         })
         setFormData({
           name: "",
           email: "",
+          password: "",
           role: "INSPECTOR",
           areaId: "",
           departmentId: "",
@@ -157,16 +162,27 @@ export function CreateUserDialog({ open, onOpenChange, onSuccess }: CreateUserDi
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="email">Email</Label>
-            <Input
-              id="email"
-              type="email"
-              value={formData.email}
-              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-              required
-              disabled={loading}
-            />
-          </div>
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            value={formData.email}
+            onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+            required
+            disabled={loading}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Password (Optional)</Label>
+          <Input
+            id="password"
+            type="password"
+            value={formData.password}
+            onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+            disabled={loading}
+          />
+        </div>
 
           <div className="space-y-2">
             <Label htmlFor="role">Role</Label>

--- a/components/admin/edit-user-dialog.tsx
+++ b/components/admin/edit-user-dialog.tsx
@@ -64,6 +64,7 @@ export function EditUserDialog({
 }: EditUserDialogProps) {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [role, setRole] = useState("");
   const [areaId, setAreaId] = useState("");
   const [departmentId, setDepartmentId] = useState("");
@@ -126,6 +127,7 @@ export function EditUserDialog({
           role,
           areaId: areaId === "NONE" ? null : areaId,
           departmentId: departmentId === "NONE" ? null : departmentId,
+          password: password || undefined,
         }),
       });
 
@@ -185,16 +187,27 @@ export function EditUserDialog({
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="email">Email *</Label>
-            <Input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="Enter email address"
-              required
-            />
-          </div>
+          <Label htmlFor="email">Email *</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Enter email address"
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Password (Optional)</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Set new password"
+          />
+        </div>
           <div className="space-y-2">
             <Label htmlFor="role">Role *</Label>
             <Select value={role} onValueChange={setRole} required>

--- a/components/mini-admin/create-user-dialog.tsx
+++ b/components/mini-admin/create-user-dialog.tsx
@@ -28,6 +28,7 @@ export function CreateUserDialog({ open, onOpenChange, onSuccess }: CreateUserDi
   const [formData, setFormData] = useState({
     name: "",
     email: "",
+    password: "",
     role: "INSPECTOR",
     departmentId: "",
   })
@@ -67,17 +68,21 @@ export function CreateUserDialog({ open, onOpenChange, onSuccess }: CreateUserDi
             formData.departmentId === "" || formData.departmentId === "none"
               ? null
               : formData.departmentId,
+          password: formData.password || undefined,
         }),
       })
 
       if (response.ok) {
         toast({
           title: "Success",
-          description: "User created successfully. They will receive an email to set their password.",
+          description: formData.password
+            ? "User created successfully."
+            : "User created successfully. They will receive an email to set their password.",
         })
         setFormData({
           name: "",
           email: "",
+          password: "",
           role: "INSPECTOR",
           departmentId: "",
         })
@@ -123,16 +128,27 @@ export function CreateUserDialog({ open, onOpenChange, onSuccess }: CreateUserDi
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="email">Email</Label>
-            <Input
-              id="email"
-              type="email"
-              value={formData.email}
-              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-              required
-              disabled={loading}
-            />
-          </div>
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            type="email"
+            value={formData.email}
+            onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+            required
+            disabled={loading}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Password (Optional)</Label>
+          <Input
+            id="password"
+            type="password"
+            value={formData.password}
+            onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+            disabled={loading}
+          />
+        </div>
 
           <div className="space-y-2">
             <Label htmlFor="role">Role</Label>

--- a/components/mini-admin/edit-user-dialog.tsx
+++ b/components/mini-admin/edit-user-dialog.tsx
@@ -37,6 +37,7 @@ interface EditUserDialogProps {
 export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUserDialogProps) {
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
   const [role, setRole] = useState("")
   const [departmentId, setDepartmentId] = useState("")
   const [departments, setDepartments] = useState<Department[]>([])
@@ -81,6 +82,7 @@ export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUser
           email: email.trim(),
           role,
           departmentId: departmentId === "NONE" ? null : departmentId,
+          password: password || undefined,
         }),
       })
 
@@ -133,16 +135,27 @@ export function EditUserDialog({ user, open, onOpenChange, onSuccess }: EditUser
             <Input id="name" value={name} onChange={(e) => setName(e.target.value)} placeholder="Enter user name" />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="email">Email *</Label>
-            <Input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="Enter email address"
-              required
-            />
-          </div>
+          <Label htmlFor="email">Email *</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Enter email address"
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Password (Optional)</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Set new password"
+          />
+        </div>
           <div className="space-y-2">
             <Label htmlFor="role">Role *</Label>
             <Select value={role} onValueChange={setRole} required>

--- a/components/mini-admin/inspections-overview.tsx
+++ b/components/mini-admin/inspections-overview.tsx
@@ -34,6 +34,7 @@ export function MiniAdminInspectionsOverview({ onUpdate }: InspectionsOverviewPr
   const [inspections, setInspections] = useState<InspectionInstance[]>([])
   const [loading, setLoading] = useState(true)
   const [downloadingPdf, setDownloadingPdf] = useState<string | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
   const { toast } = useToast()
 
   useEffect(() => {
@@ -99,6 +100,24 @@ export function MiniAdminInspectionsOverview({ onUpdate }: InspectionsOverviewPr
     }
   }
 
+  const deleteInspection = async (inspectionId: string) => {
+    setDeletingId(inspectionId)
+    try {
+      const res = await fetch(`/api/mini-admin/inspections/${inspectionId}`, { method: 'DELETE' })
+      if (res.ok) {
+        fetchInspections()
+        toast({ title: 'Success', description: 'Inspection deleted' })
+      } else {
+        const err = await res.json()
+        toast({ title: 'Error', description: err.error || 'Failed to delete inspection', variant: 'destructive' })
+      }
+    } catch {
+      toast({ title: 'Error', description: 'An unexpected error occurred', variant: 'destructive' })
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
   if (loading) {
     return (
       <Card>
@@ -150,7 +169,7 @@ export function MiniAdminInspectionsOverview({ onUpdate }: InspectionsOverviewPr
                       <StatusBadge status={status} />
                     </TableCell>
                     <TableCell>{inspection.completedAt ? formatDate(new Date(inspection.completedAt)) : "-"}</TableCell>
-                    <TableCell>
+                    <TableCell className="space-x-2">
                       {inspection.status === "COMPLETED" && (
                         <Button
                           variant="outline"
@@ -169,6 +188,16 @@ export function MiniAdminInspectionsOverview({ onUpdate }: InspectionsOverviewPr
                               PDF
                             </>
                           )}
+                        </Button>
+                      )}
+                      {inspection.status === "PENDING" && (
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => deleteInspection(inspection.id)}
+                          disabled={deletingId === inspection.id}
+                        >
+                          {deletingId === inspection.id ? "Deleting..." : "Delete"}
                         </Button>
                       )}
                     </TableCell>


### PR DESCRIPTION
## Summary
- allow admins to specify a password when creating users
- support password updates in edit dialogs
- enable Admin/Mini Admin to set passwords without sending emails
- relax inspector role checks to allow department-wide access
- update inspection list and add deletion endpoint
- allow leaders to remove unused inspections

## Testing
- `pnpm lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_b_6863977e7f0c832a89e9c15271adbed3