### PR TITLE
Allow shared checklist access across roles

### DIFF
--- a/app/api/inspector/qr-scan/[qrCodeId]/route.ts
+++ b/app/api/inspector/qr-scan/[qrCodeId]/route.ts
@@ -8,41 +8,37 @@ export async function GET(request: Request, { params }: { params: { qrCodeId: st
   try {
     const session: Session | null = await getServerSession(authOptions)
 
-    if (!session || session.user.role !== "INSPECTOR") {
+    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 
-    // Find the checklist item with this QR code
     const checklistItem = await prisma.checklistItem.findFirst({
-      where: {
-        qrCodeId: params.qrCodeId,
-      },
-      include: {
-        masterTemplate: {
-          include: {
-            inspections: {
-              where: {
-                inspectorId: session.user.id,
-                status: {
-                  not: "COMPLETED",
-                },
-              },
-              orderBy: {
-                dueDate: "asc",
-              },
-              take: 1,
-            },
-          },
-        },
-      },
+      where: { qrCodeId: params.qrCodeId },
+      include: { masterTemplate: true },
     })
 
     if (!checklistItem) {
       return NextResponse.json({ error: "QR code not found" }, { status: 404 })
     }
 
-    // Find the most recent active inspection for this template
-    const activeInspection = checklistItem.masterTemplate.inspections[0]
+    // Find the most recent active inspection for this template accessible to the user
+    const where: any = {
+      masterTemplateId: checklistItem.masterTemplateId,
+      status: { not: "COMPLETED" },
+    }
+
+    if (session.user.role === "INSPECTOR") {
+      where.departmentId = session.user.departmentId
+    } else if (session.user.role === "MINI_ADMIN") {
+      where.department = { areaId: session.user.areaId }
+    } else if (session.user.role === "ADMIN") {
+      where.department = { organizationId: session.user.organizationId }
+    }
+
+    const activeInspection = await prisma.inspectionInstance.findFirst({
+      where,
+      orderBy: { dueDate: "asc" },
+    })
 
     if (!activeInspection) {
       return NextResponse.json(


### PR DESCRIPTION
## Summary
- relax authorization for inspector QR scan route
- fetch inspections for department/area/org instead of assigned inspector

## Testing
- `pnpm lint` *(fails: interactive ESLint setup prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68639cd5e654832a8c1e06f488d02ed2