### PR TITLE
Fix duplicate import in mini-admin user route

### DIFF
--- a/app/api/mini-admin/users/[id]/route.ts
+++ b/app/api/mini-admin/users/[id]/route.ts
@@ -7,7 +7,6 @@ import { sendEmailUpdateNotification } from "@/lib/email"
 import { generateResetToken } from "@/lib/utils"
 import { createAuditLog } from "@/lib/audit"
 import bcrypt from "bcryptjs"
-import bcrypt from "bcryptjs"
 
 export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   try {


### PR DESCRIPTION
## Summary
- remove duplicate bcrypt import in mini-admin user update route

## Testing
- `pnpm lint` *(fails: interactive prompts not supported)*

------
https://chatgpt.com/codex/tasks/task_b_6863b2a0b948832ab0271c8f17855fd2