### PR TITLE
Fix template list refresh after changes

### DIFF
--- a/components/mini-admin/create-template-dialog.tsx
+++ b/components/mini-admin/create-template-dialog.tsx
@@ -82,6 +82,9 @@ export function CreateTemplateDialog({ open, onOpenChange, onSuccess }: CreateTe
         })
         onOpenChange(false)
         onSuccess()
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(new Event("template-created"))
+        }
       } else {
         const error = await response.json()
         toast({

--- a/components/mini-admin/edit-template-dialog.tsx
+++ b/components/mini-admin/edit-template-dialog.tsx
@@ -96,6 +96,9 @@ export function EditTemplateDialog({ template, open, onOpenChange, onTemplateUpd
       if (response.ok) {
         toast.success("Template updated successfully")
         onTemplateUpdated()
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(new Event("template-updated"))
+        }
         onOpenChange(false)
       } else {
         const error = await response.json()

--- a/components/mini-admin/templates-list.tsx
+++ b/components/mini-admin/templates-list.tsx
@@ -54,6 +54,16 @@ export function TemplatesList({ onUpdate, refreshKey }: TemplatesListProps) {
     fetchTemplates()
   }, [refreshKey])
 
+  useEffect(() => {
+    const handleUpdate = () => fetchTemplates()
+    window.addEventListener("template-created", handleUpdate)
+    window.addEventListener("template-updated", handleUpdate)
+    return () => {
+      window.removeEventListener("template-created", handleUpdate)
+      window.removeEventListener("template-updated", handleUpdate)
+    }
+  }, [])
+
   const fetchTemplates = async () => {
     try {
       const response = await fetch("/api/mini-admin/templates")
@@ -95,6 +105,9 @@ export function TemplatesList({ onUpdate, refreshKey }: TemplatesListProps) {
         setDeletingTemplate(null)
         onUpdate()
         fetchTemplates()
+        if (typeof window !== "undefined") {
+          window.dispatchEvent(new Event("template-updated"))
+        }
       } else {
         const error = await response.json()
         toast({


### PR DESCRIPTION
## Summary
- ensure newly created templates show immediately
- refresh template lists after edit/delete events

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6863e9d9d400832a9b5fe6befa5f919d