### PR TITLE
Fix item file preview when viewing reports

### DIFF
--- a/components/inspector/inspection-interface.tsx
+++ b/components/inspector/inspection-interface.tsx
@@ -425,6 +425,16 @@ function InspectionItemForm({ item, onSave, saving, disabled }: InspectionItemFo
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(item.result?.imageUrl ?? null)
 
+  // Reset form state when switching to a different checklist item or when the
+  // item result changes. This ensures that the preview and other fields reflect
+  // the saved data when viewing a submitted report.
+  useEffect(() => {
+    setApproved(item.result?.approved ?? true)
+    setComments(item.result?.comments ?? "")
+    setImageFile(null)
+    setImagePreview(item.result?.imageUrl ?? null)
+  }, [item.id, item.result?.approved, item.result?.comments, item.result?.imageUrl])
+
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {


### PR DESCRIPTION
## Summary
- reset InspectionItemForm state when item changes so uploaded photos show up in the report

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68676a8e98f4832aa6d0ebf20e9ea814