### PR TITLE
Enable inspection deletion for admins

### DIFF
--- a/app/api/admin/inspections/[id]/route.ts
+++ b/app/api/admin/inspections/[id]/route.ts
@@ -1,0 +1,54 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { getServerSession } from "next-auth/next"
+import type { Session } from "next-auth"
+import { authOptions } from "@/lib/auth"
+import { prisma } from "@/lib/prisma"
+import { createAuditLog } from "@/lib/audit"
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const session: Session | null = await getServerSession(authOptions)
+
+    if (!session || session.user.role !== "ADMIN") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const organizationId = session.user.organizationId
+
+    if (!organizationId) {
+      return NextResponse.json({ error: "Organization not found" }, { status: 400 })
+    }
+
+    const inspection = await prisma.inspectionInstance.findFirst({
+      where: {
+        id: params.id,
+        department: { organizationId },
+      },
+    })
+
+    if (!inspection) {
+      return NextResponse.json({ error: "Inspection not found" }, { status: 404 })
+    }
+
+    if (inspection.status !== "PENDING") {
+      return NextResponse.json(
+        { error: "Cannot delete non-pending inspection" },
+        { status: 400 },
+      )
+    }
+
+    await prisma.inspectionInstance.delete({ where: { id: params.id } })
+
+    await createAuditLog(session.user.id, "DELETE_INSPECTION", "InspectionInstance", params.id)
+
+    return NextResponse.json({ message: "Inspection deleted successfully" })
+  } catch (error) {
+    console.error("Error deleting inspection:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}
+
+export const dynamic = "force-dynamic"

--- a/components/admin/inspections-overview.tsx
+++ b/components/admin/inspections-overview.tsx
@@ -35,6 +35,7 @@ export function InspectionsOverview({ onUpdate }: InspectionsOverviewProps) {
   const [inspections, setInspections] = useState<InspectionInstance[]>([])
   const [loading, setLoading] = useState(true)
   const [downloadingPdf, setDownloadingPdf] = useState<string | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
   const { toast } = useToast()
 
   useEffect(() => {
@@ -97,6 +98,34 @@ export function InspectionsOverview({ onUpdate }: InspectionsOverviewProps) {
       })
     } finally {
       setDownloadingPdf(null)
+    }
+  }
+
+  const deleteInspection = async (inspectionId: string) => {
+    setDeletingId(inspectionId)
+    try {
+      const res = await fetch(`/api/admin/inspections/${inspectionId}`, {
+        method: "DELETE",
+      })
+      if (res.ok) {
+        fetchInspections()
+        toast({ title: "Success", description: "Inspection deleted" })
+      } else {
+        const err = await res.json()
+        toast({
+          title: "Error",
+          description: err.error || "Failed to delete inspection",
+          variant: "destructive",
+        })
+      }
+    } catch {
+      toast({
+        title: "Error",
+        description: "An unexpected error occurred",
+        variant: "destructive",
+      })
+    } finally {
+      setDeletingId(null)
     }
   }
 
@@ -182,6 +211,16 @@ export function InspectionsOverview({ onUpdate }: InspectionsOverviewProps) {
                               PDF
                             </>
                           )}
+                        </Button>
+                      )}
+                      {inspection.status === "PENDING" && (
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => deleteInspection(inspection.id)}
+                          disabled={deletingId === inspection.id}
+                        >
+                          {deletingId === inspection.id ? "Deleting..." : "Delete"}
                         </Button>
                       )}
                     </TableCell>


### PR DESCRIPTION
## Summary
- allow admin dashboard to delete inspections
- expose DELETE `/api/admin/inspections/[id]`

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_b_68676afc4d34832a96ab896094028823