### PR TITLE
Fix image preview after inspection completion

### DIFF
--- a/components/inspector/inspection-interface.tsx
+++ b/components/inspector/inspection-interface.tsx
@@ -425,6 +425,13 @@ function InspectionItemForm({ item, onSave, saving, disabled }: InspectionItemFo
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(item.result?.imageUrl ?? null)
 
+  useEffect(() => {
+    setApproved(item.result?.approved ?? true)
+    setComments(item.result?.comments ?? "")
+    setImagePreview(item.result?.imageUrl ?? null)
+    setImageFile(null)
+  }, [item])
+
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {


### PR DESCRIPTION
## Summary
- refresh item form state whenever inspection data updates so saved images appear after report submission

## Testing
- `npm run lint` *(fails: tries to access internet)*

------
https://chatgpt.com/codex/tasks/task_b_686773a2a27c832a876241739ef08c31