### PR TITLE
Fix inspection report image preview

### DIFF
--- a/components/inspector/inspection-interface.tsx
+++ b/components/inspector/inspection-interface.tsx
@@ -425,6 +425,13 @@ function InspectionItemForm({ item, onSave, saving, disabled }: InspectionItemFo
   const [imageFile, setImageFile] = useState<File | null>(null)
   const [imagePreview, setImagePreview] = useState<string | null>(item.result?.imageUrl ?? null)
 
+  useEffect(() => {
+    setApproved(item.result?.approved ?? true)
+    setComments(item.result?.comments ?? "")
+    setImageFile(null)
+    setImagePreview(item.result?.imageUrl ?? null)
+  }, [item])
+
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {


### PR DESCRIPTION
## Summary
- ensure image preview updates when navigating inspection items

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_b_686783f7c3bc832ab54f715f163193da