### PR TITLE
Restrict inspector report access

### DIFF
--- a/app/api/inspector/inspections/[id]/route.ts
+++ b/app/api/inspector/inspections/[id]/route.ts
@@ -41,11 +41,16 @@ export async function GET(request: Request, { params }: { params: { id: string }
       return NextResponse.json({ error: "Inspection not found" }, { status: 404 })
     }
 
-    if (
-      session.user.role === "INSPECTOR" &&
-      session.user.departmentId !== inspection.departmentId
-    ) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    if (session.user.role === "INSPECTOR") {
+      if (session.user.departmentId !== inspection.departmentId) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+      }
+      if (
+        inspection.status === "COMPLETED" &&
+        inspection.inspectorId !== session.user.id
+      ) {
+        return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+      }
     }
     if (
       session.user.role === "MINI_ADMIN" &&

--- a/components/inspector/inspections-list.tsx
+++ b/components/inspector/inspections-list.tsx
@@ -29,6 +29,7 @@ interface InspectionInstance {
   id: string;
   dueDate: string;
   status: string;
+  inspectorId: string;
   completedAt?: string;
   masterTemplate: {
     name: string;
@@ -285,16 +286,18 @@ export function InspectionsList() {
                             </Link>
                           </Button>
                         ) : (
-                          <Button variant="outline">
-                            <Link
-                              href={`/inspector/inspection/${inspection.id}`}
-                              className="flex items-center"
-                            >
-                              <span className="flex items-center">
-                                View Report
-                              </span>
-                            </Link>
-                          </Button>
+                          session?.user?.id === inspection.inspectorId && (
+                            <Button variant="outline">
+                              <Link
+                                href={`/inspector/inspection/${inspection.id}`}
+                                className="flex items-center"
+                              >
+                                <span className="flex items-center">
+                                  View Report
+                                </span>
+                              </Link>
+                            </Button>
+                          )
                         )}
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- restrict inspectors from viewing reports for inspections they didn't complete
- only show the `View Report` button to the inspector who completed the inspection

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run build` *(fails: cannot fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68678b6a8bdc832aaf61a196980566a5