### PR TITLE
Fix inspection deletion and button alignment

### DIFF
--- a/components/mini-admin/inspections-overview.tsx
+++ b/components/mini-admin/inspections-overview.tsx
@@ -170,7 +170,7 @@ export function MiniAdminInspectionsOverview({ onUpdate }: InspectionsOverviewPr
                       <StatusBadge status={status} />
                     </TableCell>
                     <TableCell>{inspection.completedAt ? formatDate(new Date(inspection.completedAt)) : "-"}</TableCell>
-                    <TableCell className="space-x-2">
+                    <TableCell className="flex items-center space-x-2">
                       {inspection.status !== "COMPLETED" && (
                         <Button size="sm">
                           <Link


### PR DESCRIPTION
## Summary
- allow admin users to delete inspections just like mini-admins
- align action buttons in inspection overviews

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_b_686790589ab8832aab2df1b1447e9147