### PR TITLE
Allow super admin stats view

### DIFF
--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -1,22 +1,14 @@
 import { NextResponse } from "next/server"
-import { getServerSession } from "next-auth/next"
-import { authOptions } from "@/lib/auth"
+import { getAdminContext } from "@/lib/adminContext"
 import { prisma } from "@/lib/prisma"
-import type { Session } from "next-auth"
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const session: Session | null = await getServerSession(authOptions)
-
-    if (!session || session.user.role !== "ADMIN") {
+    const context = await getAdminContext(request)
+    if (!context) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
-
-    const organizationId = session.user.organizationId
-
-    if (!organizationId) {
-      return NextResponse.json({ error: "Organization not found" }, { status: 400 })
-    }
+    const { organizationId } = context
 
     const [totalAreas, totalDepartments, totalUsers, totalTemplates, inspectionStats] = await Promise.all([
       prisma.area.count({

--- a/lib/adminContext.ts
+++ b/lib/adminContext.ts
@@ -1,0 +1,20 @@
+export async function getAdminContext(req: Request) {
+  const { getServerSession } = await import("next-auth/next")
+  const { authOptions } = await import("@/lib/auth")
+  const session = await getServerSession(authOptions)
+  if (!session) return null
+
+  if (!["ADMIN", "SUPER_ADMIN"].includes(session.user.role as string)) {
+    return null
+  }
+
+  let organizationId: string | null = null
+  if (session.user.role === "ADMIN") {
+    organizationId = session.user.organizationId
+  } else if (session.user.role === "SUPER_ADMIN") {
+    const url = new URL(req.url)
+    organizationId = url.searchParams.get("organizationId")
+  }
+  if (!organizationId) return null
+  return { session, organizationId }
+}


### PR DESCRIPTION
## Summary
- let the statistics route work with a new helper
- add helper to resolve organization when a super admin impersonates an admin

## Testing
- `npm run lint` *(fails: npm cannot access registry)*

------
https://chatgpt.com/codex/tasks/task_b_6867ac4d8980832abee0c8d712337e75