### PR TITLE
Fix super admin inspection access

### DIFF
--- a/app/api/inspector/inspections/[id]/items/[itemId]/route.ts
+++ b/app/api/inspector/inspections/[id]/items/[itemId]/route.ts
@@ -11,7 +11,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
   try {
     const session: Session | null = await getServerSession(authOptions)
 
-    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
+    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN", "SUPER_ADMIN"].includes(session.user.role)) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 

--- a/app/api/inspector/inspections/[id]/route.ts
+++ b/app/api/inspector/inspections/[id]/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: Request, { params }: { params: { id: string }
   try {
     const session: Session | null = await getServerSession(authOptions)
 
-    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
+    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN", "SUPER_ADMIN"].includes(session.user.role)) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 

--- a/app/api/inspector/inspections/[id]/submit/route.ts
+++ b/app/api/inspector/inspections/[id]/submit/route.ts
@@ -8,7 +8,7 @@ export async function POST(request: Request, { params }: { params: { id: string 
   try {
     const session: Session | null = await getServerSession(authOptions)
 
-    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
+    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN", "SUPER_ADMIN"].includes(session.user.role)) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 

--- a/app/api/inspector/inspections/route.ts
+++ b/app/api/inspector/inspections/route.ts
@@ -8,7 +8,7 @@ export async function GET() {
   try {
     const session: Session | null = await getServerSession(authOptions)
 
-    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
+    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN", "SUPER_ADMIN"].includes(session.user.role)) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 

--- a/app/api/inspector/qr-scan/[qrCodeId]/route.ts
+++ b/app/api/inspector/qr-scan/[qrCodeId]/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: Request, { params }: { params: { qrCodeId: st
   try {
     const session: Session | null = await getServerSession(authOptions)
 
-    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
+    if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN", "SUPER_ADMIN"].includes(session.user.role)) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     }
 

--- a/app/inspector/inspection/[id]/page.tsx
+++ b/app/inspector/inspection/[id]/page.tsx
@@ -13,7 +13,7 @@ interface InspectionPageProps {
 export default async function InspectionPage({ params }: InspectionPageProps) {
   const session: Session | null = await getServerSession(authOptions)
 
-  if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
+  if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN", "SUPER_ADMIN"].includes(session.user.role)) {
     redirect("/auth/signin")
   }
 

--- a/app/inspector/inspections/page.tsx
+++ b/app/inspector/inspections/page.tsx
@@ -7,7 +7,7 @@ import { InspectionsList } from "@/components/inspector/inspections-list"
 export default async function InspectionsPage() {
   const session: Session | null = await getServerSession(authOptions)
 
-  if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
+  if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN", "SUPER_ADMIN"].includes(session.user.role)) {
     redirect("/auth/signin")
   }
 

--- a/app/inspector/page.tsx
+++ b/app/inspector/page.tsx
@@ -7,7 +7,7 @@ import { InspectorDashboard } from "@/components/inspector/dashboard"
 export default async function InspectorPage() {
   const session: Session | null = await getServerSession(authOptions)
 
-  if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN"].includes(session.user.role)) {
+  if (!session || !["INSPECTOR", "MINI_ADMIN", "ADMIN", "SUPER_ADMIN"].includes(session.user.role)) {
     redirect("/auth/signin")
   }
 


### PR DESCRIPTION
## Summary
- allow SUPER_ADMIN role to use inspector APIs and pages

## Testing
- `npm run lint` *(fails: npm prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6867e83c4b64832aa23ed1a3a253d1fe