### PR TITLE
Fix super admin management for users/templates

### DIFF
--- a/components/admin/dashboard.tsx
+++ b/components/admin/dashboard.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { useSession } from "next-auth/react"
 import { Navigation } from "@/components/ui/navigation"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import Link from "next/link"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
 import { AreasManagement } from "./areas-management"
@@ -119,6 +120,13 @@ export function AdminDashboard({
               </p>
             </div>
             <div className="flex items-center gap-2">
+              {session?.user?.role === "SUPER_ADMIN" && (
+                <Link href="/super-admin">
+                  <Button variant="ghost" className="glass">
+                    Back to Super Admin
+                  </Button>
+                </Link>
+              )}
               <div className="px-3 py-1.5 bg-gradient-to-r from-blue-100 to-indigo-100 text-blue-800 rounded-full text-sm font-medium">
                 <TrendingUp className="inline h-4 w-4 mr-1" />
                 All Systems Active

--- a/components/admin/templates-management.tsx
+++ b/components/admin/templates-management.tsx
@@ -9,9 +9,13 @@ import { TemplatesList } from "./templates-list"
 
 interface TemplatesManagementProps {
   onUpdate: () => void
+  organizationId?: string
 }
 
-export function TemplatesManagement({ onUpdate }: TemplatesManagementProps) {
+export function TemplatesManagement({
+  onUpdate,
+  organizationId,
+}: TemplatesManagementProps) {
   const [showCreateDialog, setShowCreateDialog] = useState(false)
 
   return (
@@ -29,10 +33,15 @@ export function TemplatesManagement({ onUpdate }: TemplatesManagementProps) {
         </div>
       </CardHeader>
       <CardContent>
-        <TemplatesList onUpdate={onUpdate} />
+        <TemplatesList onUpdate={onUpdate} organizationId={organizationId} />
       </CardContent>
 
-      <CreateTemplateDialog open={showCreateDialog} onOpenChange={setShowCreateDialog} onSuccess={onUpdate} />
+      <CreateTemplateDialog
+        open={showCreateDialog}
+        onOpenChange={setShowCreateDialog}
+        onSuccess={onUpdate}
+        organizationId={organizationId}
+      />
     </Card>
   )
 }

--- a/components/admin/users-management.tsx
+++ b/components/admin/users-management.tsx
@@ -9,9 +9,13 @@ import { UsersList } from "./users-list"
 
 interface UsersManagementProps {
   onUpdate: () => void
+  organizationId?: string
 }
 
-export function UsersManagement({ onUpdate }: UsersManagementProps) {
+export function UsersManagement({
+  onUpdate,
+  organizationId,
+}: UsersManagementProps) {
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [listKey, setListKey] = useState(0)
 
@@ -30,7 +34,11 @@ export function UsersManagement({ onUpdate }: UsersManagementProps) {
         </div>
       </CardHeader>
       <CardContent>
-        <UsersList key={listKey} onUpdate={onUpdate} />
+        <UsersList
+          key={listKey}
+          onUpdate={onUpdate}
+          organizationId={organizationId}
+        />
       </CardContent>
 
       <CreateUserDialog
@@ -40,6 +48,7 @@ export function UsersManagement({ onUpdate }: UsersManagementProps) {
           onUpdate()
           setListKey((k) => k + 1)
         }}
+        organizationId={organizationId}
       />
     </Card>
   )


### PR DESCRIPTION
## Summary
- allow organizationId to flow into UsersManagement
- allow organizationId to flow into TemplatesManagement

## Testing
- `npm run lint` *(fails: prompts for interactive config)*

------
https://chatgpt.com/codex/tasks/task_b_6867ea664274832aaa8d67dce3ea8d17