### PR TITLE
Enable QR code scanning on admin dashboards

### DIFF
--- a/components/admin/dashboard.tsx
+++ b/components/admin/dashboard.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react"
 import { useSession } from "next-auth/react"
 import { Navigation } from "@/components/ui/navigation"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import Link from "next/link"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Button } from "@/components/ui/button"
 import { AreasManagement } from "./areas-management"
@@ -13,6 +14,7 @@ import { TemplatesManagement } from "./templates-management"
 import { InspectionsOverview } from "./inspections-overview"
 import { buildAdminApiUrl } from "@/lib/admin"
 import { CreateInspectionDialog } from "./create-inspection-dialog"
+import { QRScanner } from "@/components/inspector/qr-scanner"
 import {
   Building2,
   Users,
@@ -24,6 +26,8 @@ import {
   CheckCircle,
   AlertTriangle,
   TrendingUp,
+  QrCode,
+  Zap,
 } from "lucide-react"
 
 interface DashboardStats {
@@ -58,6 +62,7 @@ export function AdminDashboard({
     overdueInspections: 0,
   })
   const [createInspectionOpen, setCreateInspectionOpen] = useState(false)
+  const [showQRScanner, setShowQRScanner] = useState(false)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -119,6 +124,13 @@ export function AdminDashboard({
               </p>
             </div>
             <div className="flex items-center gap-2">
+              {session?.user?.role === "SUPER_ADMIN" && (
+                <Link href="/super-admin">
+                  <Button variant="ghost" className="glass">
+                    Back to Super Admin
+                  </Button>
+                </Link>
+              )}
               <div className="px-3 py-1.5 bg-gradient-to-r from-blue-100 to-indigo-100 text-blue-800 rounded-full text-sm font-medium">
                 <TrendingUp className="inline h-4 w-4 mr-1" />
                 All Systems Active
@@ -191,6 +203,28 @@ export function AdminDashboard({
                 {stats.activeInspections}
               </div>
               <p className="text-xs text-gray-600 mt-1">In progress</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Quick Actions */}
+        <div className="mb-8 animate-slide-up">
+          <Card variant="glass" className="overflow-hidden">
+            <CardHeader className="bg-gradient-to-r from-blue-600 to-blue-700 text-white">
+              <CardTitle className="flex items-center gap-2">
+                <Zap className="h-5 w-5" />
+                Quick Actions
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-6">
+              <Button
+                onClick={() => setShowQRScanner(true)}
+                className="h-14 text-base font-semibold flex items-center"
+                size="lg"
+              >
+                <QrCode className="mr-3 h-5 w-5" />
+                <span>Scan QR Code</span>
+              </Button>
             </CardContent>
           </Card>
         </div>
@@ -331,6 +365,10 @@ export function AdminDashboard({
           onOpenChange={setCreateInspectionOpen}
           onSuccess={handleCreateInspectionSuccess}
           organizationId={organizationId}
+        />
+        <QRScanner
+          open={showQRScanner}
+          onClose={() => setShowQRScanner(false)}
         />
       </div>
     </div>

--- a/components/admin/templates-management.tsx
+++ b/components/admin/templates-management.tsx
@@ -9,9 +9,13 @@ import { TemplatesList } from "./templates-list"
 
 interface TemplatesManagementProps {
   onUpdate: () => void
+  organizationId?: string
 }
 
-export function TemplatesManagement({ onUpdate }: TemplatesManagementProps) {
+export function TemplatesManagement({
+  onUpdate,
+  organizationId,
+}: TemplatesManagementProps) {
   const [showCreateDialog, setShowCreateDialog] = useState(false)
 
   return (
@@ -29,10 +33,15 @@ export function TemplatesManagement({ onUpdate }: TemplatesManagementProps) {
         </div>
       </CardHeader>
       <CardContent>
-        <TemplatesList onUpdate={onUpdate} />
+        <TemplatesList onUpdate={onUpdate} organizationId={organizationId} />
       </CardContent>
 
-      <CreateTemplateDialog open={showCreateDialog} onOpenChange={setShowCreateDialog} onSuccess={onUpdate} />
+      <CreateTemplateDialog
+        open={showCreateDialog}
+        onOpenChange={setShowCreateDialog}
+        onSuccess={onUpdate}
+        organizationId={organizationId}
+      />
     </Card>
   )
 }

--- a/components/admin/users-management.tsx
+++ b/components/admin/users-management.tsx
@@ -9,9 +9,13 @@ import { UsersList } from "./users-list"
 
 interface UsersManagementProps {
   onUpdate: () => void
+  organizationId?: string
 }
 
-export function UsersManagement({ onUpdate }: UsersManagementProps) {
+export function UsersManagement({
+  onUpdate,
+  organizationId,
+}: UsersManagementProps) {
   const [showCreateDialog, setShowCreateDialog] = useState(false)
   const [listKey, setListKey] = useState(0)
 
@@ -30,7 +34,11 @@ export function UsersManagement({ onUpdate }: UsersManagementProps) {
         </div>
       </CardHeader>
       <CardContent>
-        <UsersList key={listKey} onUpdate={onUpdate} />
+        <UsersList
+          key={listKey}
+          onUpdate={onUpdate}
+          organizationId={organizationId}
+        />
       </CardContent>
 
       <CreateUserDialog
@@ -40,6 +48,7 @@ export function UsersManagement({ onUpdate }: UsersManagementProps) {
           onUpdate()
           setListKey((k) => k + 1)
         }}
+        organizationId={organizationId}
       />
     </Card>
   )

--- a/components/inspector/inspection-interface.tsx
+++ b/components/inspector/inspection-interface.tsx
@@ -4,6 +4,7 @@ import type React from "react"
 
 import { useState, useEffect } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
+import { useSession } from "next-auth/react"
 import { Navigation } from "@/components/ui/navigation"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
@@ -13,7 +14,7 @@ import { Label } from "@/components/ui/label"
 import { Input } from "@/components/ui/input"
 import { useToast } from "@/hooks/use-toast"
 import { CheckCircle, XCircle, ArrowLeft, ArrowRight, Save, Send, Download } from "lucide-react"
-import { formatDate } from "@/lib/utils"
+import { formatDate, getDashboardPath } from "@/lib/utils"
 
 interface InspectionItem {
   id: string
@@ -58,6 +59,7 @@ export function InspectionInterface({ inspectionId }: InspectionInterfaceProps) 
   const { toast } = useToast()
   const router = useRouter()
   const searchParams = useSearchParams()
+  const { data: session } = useSession()
 
   useEffect(() => {
     const initialize = async () => {
@@ -93,7 +95,7 @@ export function InspectionInterface({ inspectionId }: InspectionInterfaceProps) 
         description: error.message || "Failed to load inspection",
         variant: "destructive",
       })
-      router.push("/inspector")
+      router.push(getDashboardPath(session?.user.role))
       return null
     } catch (error) {
       console.error("Failed to fetch inspection:", error)
@@ -102,7 +104,7 @@ export function InspectionInterface({ inspectionId }: InspectionInterfaceProps) 
         description: "An unexpected error occurred",
         variant: "destructive",
       })
-      router.push("/inspector")
+      router.push(getDashboardPath(session?.user.role))
       return null
     } finally {
       setLoading(false)
@@ -283,7 +285,11 @@ export function InspectionInterface({ inspectionId }: InspectionInterfaceProps) 
         {/* Header */}
         <div className="mb-6">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <Button variant="outline" onClick={() => router.push("/inspector")} className="w-full sm:w-auto">
+            <Button
+              variant="outline"
+              onClick={() => router.push(getDashboardPath(session?.user.role))}
+              className="w-full sm:w-auto"
+            >
               <ArrowLeft className="mr-2 h-4 w-4" />
               Back to Dashboard
             </Button>

--- a/components/inspector/inspections-list.tsx
+++ b/components/inspector/inspections-list.tsx
@@ -22,7 +22,7 @@ import {
   CheckCircle,
   Clock,
 } from "lucide-react";
-import { getInspectionStatus, formatDate } from "@/lib/utils";
+import { getInspectionStatus, formatDate, getDashboardPath } from "@/lib/utils";
 import Link from "next/link";
 
 interface InspectionInstance {
@@ -148,7 +148,7 @@ export function InspectionsList() {
         <div className="mb-6">
           <div className="flex items-center justify-between">
             <Button variant="outline">
-              <Link href="/inspector" className="flex items-center">
+              <Link href={getDashboardPath(session?.user?.role)} className="flex items-center">
                 <span className="flex items-center">
                   <ArrowLeft className="mr-2 h-4 w-4" />
                   Back to Dashboard

--- a/components/mini-admin/dashboard.tsx
+++ b/components/mini-admin/dashboard.tsx
@@ -11,6 +11,7 @@ import { MiniAdminUsersManagement } from "./users-management"
 import { MiniAdminTemplatesManagement } from "./templates-management"
 import { MiniAdminInspectionsOverview } from "./inspections-overview"
 import { CreateInspectionDialog } from "./create-inspection-dialog"
+import { QRScanner } from "@/components/inspector/qr-scanner"
 import {
   Building2,
   Users,
@@ -23,6 +24,8 @@ import {
   AlertTriangle,
   MapPin,
   TrendingUp,
+  QrCode,
+  Zap,
 } from "lucide-react"
 
 interface DashboardStats {
@@ -53,6 +56,7 @@ export function MiniAdminDashboard() {
     areaName: "",
   })
   const [createInspectionOpen, setCreateInspectionOpen] = useState(false)
+  const [showQRScanner, setShowQRScanner] = useState(false)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -175,6 +179,28 @@ export function MiniAdminDashboard() {
                 {stats.activeInspections}
               </div>
               <p className="text-xs text-gray-600 mt-1">In progress</p>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Quick Actions */}
+        <div className="mb-8 animate-slide-up">
+          <Card variant="glass" className="overflow-hidden">
+            <CardHeader className="bg-gradient-to-r from-emerald-600 to-emerald-700 text-white">
+              <CardTitle className="flex items-center gap-2">
+                <Zap className="h-5 w-5" />
+                Quick Actions
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="p-6">
+              <Button
+                onClick={() => setShowQRScanner(true)}
+                className="h-14 text-base font-semibold flex items-center"
+                size="lg"
+              >
+                <QrCode className="mr-3 h-5 w-5" />
+                <span>Scan QR Code</span>
+              </Button>
             </CardContent>
           </Card>
         </div>
@@ -304,6 +330,10 @@ export function MiniAdminDashboard() {
           open={createInspectionOpen}
           onOpenChange={setCreateInspectionOpen}
           onSuccess={handleCreateInspectionSuccess}
+        />
+        <QRScanner
+          open={showQRScanner}
+          onClose={() => setShowQRScanner(false)}
         />
       </div>
     </div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -37,3 +37,18 @@ export function generatePDFFilename(departmentName: string, templateName: string
   const sanitizedTemplate = templateName.toLowerCase().replace(/\s+/g, "_")
   return `${sanitizedDept}_${sanitizedTemplate}_${formattedDate}.pdf`
 }
+
+export function getDashboardPath(role?: string): string {
+  switch (role) {
+    case "SUPER_ADMIN":
+      return "/super-admin"
+    case "ADMIN":
+      return "/admin"
+    case "MINI_ADMIN":
+      return "/mini-admin"
+    case "INSPECTOR":
+      return "/inspector"
+    default:
+      return "/inspector"
+  }
+}


### PR DESCRIPTION
## Summary
- import `QRScanner` component and relevant icons
- add `showQRScanner` state on both admin and mini-admin dashboards
- add Quick Actions section with "Scan QR Code" button
- render `QRScanner` dialog when scanning is triggered

## Testing
- `npm run lint` *(fails: prompts for interactive config)*

------
https://chatgpt.com/codex/tasks/task_b_6867ea664274832aaa8d67dce3ea8d17