### PR TITLE
Fix template list refresh

### DIFF
--- a/components/admin/templates-list.tsx
+++ b/components/admin/templates-list.tsx
@@ -38,10 +38,15 @@ interface Template {
 
 interface TemplatesListProps {
   onUpdate: () => void
+  refreshKey: number
   organizationId?: string
 }
 
-export function TemplatesList({ onUpdate, organizationId }: TemplatesListProps) {
+export function TemplatesList({
+  onUpdate,
+  organizationId,
+  refreshKey,
+}: TemplatesListProps) {
   const [templates, setTemplates] = useState<Template[]>([])
   const [loading, setLoading] = useState(true)
   const [editingTemplate, setEditingTemplate] = useState<Template | null>(null)
@@ -52,7 +57,7 @@ export function TemplatesList({ onUpdate, organizationId }: TemplatesListProps) 
 
   useEffect(() => {
     fetchTemplates()
-  }, [])
+  }, [refreshKey])
 
   const fetchTemplates = async () => {
     try {

--- a/components/admin/templates-management.tsx
+++ b/components/admin/templates-management.tsx
@@ -17,6 +17,7 @@ export function TemplatesManagement({
   organizationId,
 }: TemplatesManagementProps) {
   const [showCreateDialog, setShowCreateDialog] = useState(false)
+  const [refreshKey, setRefreshKey] = useState(0)
 
   return (
     <Card>
@@ -33,13 +34,20 @@ export function TemplatesManagement({
         </div>
       </CardHeader>
       <CardContent>
-        <TemplatesList onUpdate={onUpdate} organizationId={organizationId} />
+        <TemplatesList
+          onUpdate={onUpdate}
+          organizationId={organizationId}
+          refreshKey={refreshKey}
+        />
       </CardContent>
 
       <CreateTemplateDialog
         open={showCreateDialog}
         onOpenChange={setShowCreateDialog}
-        onSuccess={onUpdate}
+        onSuccess={() => {
+          onUpdate()
+          setRefreshKey((k) => k + 1)
+        }}
         organizationId={organizationId}
       />
     </Card>

--- a/components/mini-admin/template-items-management.tsx
+++ b/components/mini-admin/template-items-management.tsx
@@ -21,9 +21,12 @@ export function MiniAdminTemplateItemsManagement({ templateId, templateName, onU
   const [selectedItem, setSelectedItem] = useState<any>(null)
   const [items, setItems] = useState([])
   const [loading, setLoading] = useState(false)
+  const [loadingItems, setLoadingItems] = useState(true)
+  const [refreshKey, setRefreshKey] = useState(0)
   const { toast } = useToast()
 
   const fetchItems = async () => {
+    setLoadingItems(true)
     try {
       const response = await fetch(`/api/mini-admin/template-items?templateId=${templateId}`)
       if (response.ok) {
@@ -32,12 +35,14 @@ export function MiniAdminTemplateItemsManagement({ templateId, templateName, onU
       }
     } catch (error) {
       console.error("Failed to fetch items:", error)
+    } finally {
+      setLoadingItems(false)
     }
   }
 
   useEffect(() => {
     fetchItems()
-  }, [templateId])
+  }, [templateId, refreshKey])
 
   const handleDownloadAllQR = async () => {
     setLoading(true)
@@ -103,15 +108,19 @@ export function MiniAdminTemplateItemsManagement({ templateId, templateName, onU
           </div>
         </CardHeader>
         <CardContent className="overflow-auto">
-          <TemplateItemsList
-            templateId={templateId}
-            items={items}
-            onUpdate={() => {
-              fetchItems()
-              onUpdate()
-            }}
-            onShowQR={handleShowQR}
-          />
+          {loadingItems ? (
+            <div className="text-center py-4">Loading items...</div>
+          ) : (
+            <TemplateItemsList
+              templateId={templateId}
+              items={items}
+              onUpdate={() => {
+                setRefreshKey((k) => k + 1)
+                onUpdate()
+              }}
+              onShowQR={handleShowQR}
+            />
+          )}
         </CardContent>
       </Card>
 
@@ -120,7 +129,7 @@ export function MiniAdminTemplateItemsManagement({ templateId, templateName, onU
         onOpenChange={setShowCreateDialog}
         templateId={templateId}
         onSuccess={() => {
-          fetchItems()
+          setRefreshKey((k) => k + 1)
           onUpdate()
         }}
       />


### PR DESCRIPTION
## Summary
- refresh admin templates dynamically after creating a new one
- ensure mini-admin template items refresh after create/update
- show loading state while template items load

## Testing
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_b_686c01a9dff4832a86838b4ac47e57f9