### PR TITLE
Fix admin url builder

### DIFF
--- a/lib/admin.ts
+++ b/lib/admin.ts
@@ -1,5 +1,10 @@
 export function buildAdminApiUrl(path: string, organizationId?: string) {
-  return organizationId ? `${path}?organizationId=${organizationId}` : path;
+  if (!organizationId) {
+    return path;
+  }
+
+  const separator = path.includes("?") ? "&" : "?";
+  return `${path}${separator}organizationId=${organizationId}`;
 }
 
 export function extractOrganizationId(session: any, request: Request) {


### PR DESCRIPTION
## Summary
- fix `buildAdminApiUrl` when a path already has query params

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_686c2970ce1c832aade4400ff52ea91b