### PR TITLE
Fix edit template dialog closing

### DIFF
--- a/components/admin/edit-template-dialog.tsx
+++ b/components/admin/edit-template-dialog.tsx
@@ -45,11 +45,11 @@ interface EditTemplateDialogProps {
   template: Template | null
   open: boolean
   onOpenChange: (open: boolean) => void
-  onTemplateUpdated: () => void
+  onSuccess: () => void
   organizationId?: string
 }
 
-export function EditTemplateDialog({ template, open, onOpenChange, onTemplateUpdated, organizationId }: EditTemplateDialogProps) {
+export function EditTemplateDialog({ template, open, onOpenChange, onSuccess, organizationId }: EditTemplateDialogProps) {
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
   const [departmentId, setDepartmentId] = useState<string>("none")
@@ -107,7 +107,7 @@ export function EditTemplateDialog({ template, open, onOpenChange, onTemplateUpd
 
       if (response.ok) {
         toast.success("Template updated successfully")
-        onTemplateUpdated()
+        onSuccess()
         onOpenChange(false)
       } else {
         const error = await response.json()

--- a/components/mini-admin/edit-template-dialog.tsx
+++ b/components/mini-admin/edit-template-dialog.tsx
@@ -39,10 +39,10 @@ interface EditTemplateDialogProps {
   template: Template | null
   open: boolean
   onOpenChange: (open: boolean) => void
-  onTemplateUpdated: () => void
+  onSuccess: () => void
 }
 
-export function EditTemplateDialog({ template, open, onOpenChange, onTemplateUpdated }: EditTemplateDialogProps) {
+export function EditTemplateDialog({ template, open, onOpenChange, onSuccess }: EditTemplateDialogProps) {
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
   const [departmentId, setDepartmentId] = useState<string>("none")
@@ -95,7 +95,7 @@ export function EditTemplateDialog({ template, open, onOpenChange, onTemplateUpd
 
       if (response.ok) {
         toast.success("Template updated successfully")
-        onTemplateUpdated()
+        onSuccess()
         if (typeof window !== "undefined") {
           window.dispatchEvent(new Event("template-updated"))
         }


### PR DESCRIPTION
## Summary
- rename `onTemplateUpdated` prop to `onSuccess` in edit template dialogs

## Testing
- `npm run lint` *(fails: asks to configure ESLint without network)*

------
https://chatgpt.com/codex/tasks/task_b_686c2fe770d0832a8d99412ca77fb7ea