### PR TITLE
Handle role-based clearing of area & department

### DIFF
--- a/app/api/admin/users/[id]/route.ts
+++ b/app/api/admin/users/[id]/route.ts
@@ -25,6 +25,16 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
     const { name, email, role, areaId, departmentId, password } = await request.json()
 
+    // Determine new area/department based on role
+    let newAreaId = areaId === "NONE" ? null : areaId
+    let newDepartmentId = departmentId === "NONE" ? null : departmentId
+    if (role === "ADMIN") {
+      newAreaId = null
+      newDepartmentId = null
+    } else if (role === "MINI_ADMIN") {
+      newDepartmentId = null
+    }
+
     // Verify user belongs to organization
     const existingUser = await prisma.user.findFirst({
       where: {
@@ -52,10 +62,10 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
     }
 
     // Verify area and department belong to organization
-    if (areaId && areaId !== "NONE") {
+    if (newAreaId) {
       const area = await prisma.area.findFirst({
         where: {
-          id: areaId,
+          id: newAreaId,
           organizationId,
         },
       })
@@ -65,10 +75,10 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       }
     }
 
-    if (departmentId && departmentId !== "NONE") {
+    if (newDepartmentId) {
       const department = await prisma.department.findFirst({
         where: {
-          id: departmentId,
+          id: newDepartmentId,
           organizationId,
         },
       })
@@ -95,8 +105,8 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       name,
       email,
       role: role as any,
-      areaId: areaId === "NONE" ? null : areaId,
-      departmentId: departmentId === "NONE" ? null : departmentId,
+      areaId: newAreaId,
+      departmentId: newDepartmentId,
     }
     if (emailChanged) {
       updateData.password = null

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -65,6 +65,15 @@ export async function POST(request: NextRequest) {
 
     const { name, email, role, areaId, departmentId, password } = await request.json()
 
+    let newAreaId = areaId === "NONE" || areaId === "" ? null : areaId
+    let newDepartmentId = departmentId === "NONE" || departmentId === "" ? null : departmentId
+    if (role === "ADMIN") {
+      newAreaId = null
+      newDepartmentId = null
+    } else if (role === "MINI_ADMIN") {
+      newDepartmentId = null
+    }
+
     // Check if email already exists (case-insensitive)
     const existingUser = await prisma.user.findFirst({
       where: { email: { equals: email, mode: "insensitive" } },
@@ -75,10 +84,10 @@ export async function POST(request: NextRequest) {
     }
 
     // Verify area and department belong to the organization
-    if (areaId && areaId !== "NONE" && areaId !== "") {
+    if (newAreaId) {
       const area = await prisma.area.findFirst({
         where: {
-          id: areaId,
+          id: newAreaId,
           organizationId,
         },
       })
@@ -88,10 +97,10 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    if (departmentId && departmentId !== "NONE" && departmentId !== "") {
+    if (newDepartmentId) {
       const department = await prisma.department.findFirst({
         where: {
-          id: departmentId,
+          id: newDepartmentId,
           organizationId,
         },
       })
@@ -122,8 +131,8 @@ export async function POST(request: NextRequest) {
           password: hashedPassword,
           role: role as any,
           organizationId,
-          areaId: areaId === "NONE" || areaId === "" ? null : areaId,
-          departmentId: departmentId === "NONE" || departmentId === "" ? null : departmentId,
+          areaId: newAreaId,
+          departmentId: newDepartmentId,
         },
       })
 

--- a/app/api/mini-admin/users/[id]/route.ts
+++ b/app/api/mini-admin/users/[id]/route.ts
@@ -24,6 +24,11 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
     const { name, email, role, departmentId, password } = await request.json()
 
+    let newDepartmentId = departmentId || null
+    if (role === "MINI_ADMIN") {
+      newDepartmentId = null
+    }
+
     // Verify user belongs to area
     const existingUser = await prisma.user.findFirst({
       where: {
@@ -51,10 +56,10 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
     }
 
     // Verify department belongs to area if provided
-    if (departmentId) {
+    if (newDepartmentId) {
       const department = await prisma.department.findFirst({
         where: {
-          id: departmentId,
+          id: newDepartmentId,
           areaId,
         },
       })
@@ -81,7 +86,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       name,
       email,
       role: role as any,
-      departmentId: departmentId || null,
+      departmentId: newDepartmentId,
     }
 
     if (emailChanged) {

--- a/app/api/mini-admin/users/route.ts
+++ b/app/api/mini-admin/users/route.ts
@@ -60,6 +60,11 @@ export async function POST(request: NextRequest) {
 
     const { name, email, role, departmentId, password } = await request.json()
 
+    let newDepartmentId = departmentId || null
+    if (role === "MINI_ADMIN") {
+      newDepartmentId = null
+    }
+
     // Check if email already exists (case-insensitive)
     const existingUser = await prisma.user.findFirst({
       where: { email: { equals: email, mode: "insensitive" } },
@@ -70,10 +75,10 @@ export async function POST(request: NextRequest) {
     }
 
     // Verify department belongs to the area
-    if (departmentId) {
+    if (newDepartmentId) {
       const department = await prisma.department.findFirst({
         where: {
-          id: departmentId,
+          id: newDepartmentId,
           areaId,
         },
       })
@@ -105,7 +110,7 @@ export async function POST(request: NextRequest) {
           role: role as any,
           organizationId,
           areaId,
-          departmentId: departmentId || null,
+          departmentId: newDepartmentId,
         },
       })
 


### PR DESCRIPTION
## Summary
- clear department and area when promoting users
- clear department when setting user as MINI_ADMIN

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_687521279364832ab66f7544771c734c