### PR TITLE
Improve inspection sorting and QR scanning

### DIFF
--- a/components/inspector/inspections-list.tsx
+++ b/components/inspector/inspections-list.tsx
@@ -100,6 +100,23 @@ export function InspectionsList() {
       });
     }
 
+    const statusPriority: Record<string, number> = {
+      IN_PROGRESS: 0,
+      PENDING: 1,
+      OVERDUE: 2,
+      COMPLETED: 3,
+    };
+
+    filtered.sort((a, b) => {
+      const statusDiff =
+        statusPriority[a.status as keyof typeof statusPriority] -
+        statusPriority[b.status as keyof typeof statusPriority];
+      if (statusDiff !== 0) return statusDiff;
+      return (
+        new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime()
+      );
+    });
+
     setFilteredInspections(filtered);
   };
 

--- a/components/inspector/qr-scanner.tsx
+++ b/components/inspector/qr-scanner.tsx
@@ -21,6 +21,7 @@ export function QRScanner({ open, onClose }: QRScannerProps) {
   const [showManualInput, setShowManualInput] = useState(false)
   const [manualCode, setManualCode] = useState("")
   const [errorMsg, setErrorMsg] = useState("")
+  const [hasScanned, setHasScanned] = useState(false)
   const { toast } = useToast()
   const router = useRouter()
 
@@ -33,6 +34,8 @@ export function QRScanner({ open, onClose }: QRScannerProps) {
   }, [open])
 
   const handleQRCodeFound = async (qrCodeId: string) => {
+    if (hasScanned) return
+    setHasScanned(true)
     try {
       const response = await fetch(`/api/inspector/qr-scan/${qrCodeId}`)
 
@@ -73,6 +76,7 @@ export function QRScanner({ open, onClose }: QRScannerProps) {
     setManualCode("")
     setShowManualInput(false)
     setErrorMsg("")
+    setHasScanned(false)
     onClose()
   }
 


### PR DESCRIPTION
## Summary
- ensure inspector listings are sorted by status then by due date
- prevent duplicate QR scan messages by ignoring repeated detections

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npx tsc -p tsconfig.json` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_b_6883d0c3df4c832a9d3f12101c09ce5c